### PR TITLE
Support refresh page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3006,8 +3006,7 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
@@ -3029,7 +3028,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7096,8 +7094,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7134,8 +7131,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -7144,8 +7140,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7248,8 +7243,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7259,7 +7253,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7285,7 +7278,6 @@
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7302,7 +7294,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7375,8 +7366,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7386,7 +7376,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7462,8 +7451,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7493,7 +7481,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7511,7 +7498,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7550,13 +7536,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -9061,6 +9045,22 @@
         "prepend-http": "^1.0.0",
         "query-string": "^4.1.0",
         "sort-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+        }
       }
     },
     "npm-run-path": {
@@ -10713,12 +10713,13 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.3.tgz",
+      "integrity": "sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -12296,6 +12297,11 @@
         "wbuf": "^1.7.3"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -12488,9 +12494,9 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "carbon-components-react": "^7.6.4",
     "carbon-icons": "^7.0.7",
     "node-sass": "^4.12.0",
+    "query-string": "^6.8.3",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-scripts": "3.1.2"

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,11 @@
 import React from 'react';
-import Home from './components/Home'
-import { Button } from 'carbon-components-react';
+import Router from './components/Router'
 import './app.scss';
 
 function App() {
   return (
     <div className="App">
-      <Home />
-      
+      <Router />
     </div>
   );
 }

--- a/src/components/Event.js
+++ b/src/components/Event.js
@@ -1,6 +1,21 @@
 import React, { Component } from 'react'
 
 export default class Event extends Component {
+  constructor(props){
+    super(props)
 
-  
+    this.state = {}
+  }
+  render(){
+    let event = this.props.event
+
+    return (
+      <div>
+        <h1>Event: {event.ename}</h1>
+        <p># Registered: {event.regNum}</p>
+        <p># Checked In: {event.checkedNum}</p>
+        <p># Waitlisted: {event.waitNum}</p>
+      </div>
+    )
+  }
 }

--- a/src/components/Event.js
+++ b/src/components/Event.js
@@ -1,0 +1,6 @@
+import React, { Component } from 'react'
+
+export default class Event extends Component {
+
+  
+}

--- a/src/components/EventSelector.js
+++ b/src/components/EventSelector.js
@@ -5,8 +5,7 @@ export default class EventSelector extends Component {
     super(props);
 
     this.state = {
-      events: null,
-      selected: -1,
+      events: null
     }
     this.handleChange = this.handleChange.bind(this);
 }
@@ -18,7 +17,6 @@ export default class EventSelector extends Component {
         this.setState({
           events: response
         })
-        console.log(response)
         console.log(this.state.events)
       })
     }
@@ -39,13 +37,13 @@ export default class EventSelector extends Component {
 
     handleChange(event) {
       if (event.target.value != -1) {
-        this.setState({selected: event.target.value});
+        // this.setState({selected: event.target.value});
+        window.location = '/?event=' + this.state.events[event.target.value].id
       }
     }
 
     render() {
       let events = this.state.events;
-      let index = this.state.selected;
 
       if (events === null){
         return (
@@ -53,38 +51,20 @@ export default class EventSelector extends Component {
             <p>Loading...</p>
           </div>
       )}
-      else if (index === -1) {
+      else {
         return (
           <div>
             <h1>Events Check-in</h1>
 
         <form>
         <label>
-            Select Event:
+            Select Event: 
             <select onChange={this.handleChange}>
             {this.createDropdownItems()}
             </select>
         </label>
         </form>
 
-        </div>
-        );
-      } else {
-        return (
-          <div>
-            <h1>Events Check-in</h1>
-
-        <form>
-        <label>
-            Select Event:
-            <select value={this.state.selected} onChange={this.handleChange}>
-            {this.createDropdownItems()}
-            </select>
-        </label>
-        </form>
-        <p># Registered: {events[index].regNum}</p>
-        <p># Checked In: {events[index].checkedNum}</p>
-        <p># Waitlisted: {events[index].waitNum}</p>
         </div>
         );
       }

--- a/src/components/EventSelector.js
+++ b/src/components/EventSelector.js
@@ -5,21 +5,10 @@ export default class EventSelector extends Component {
     super(props);
 
     this.state = {
-      events: null
+      events: this.props.events
     }
     this.handleChange = this.handleChange.bind(this);
 }
-    componentDidMount() {
-      fetch(process.env.REACT_APP_AMAZON_API+"/events/get", {
-      })
-      .then((response) => response.json())
-      .then((response) => {
-        this.setState({
-          events: response
-        })
-        console.log(this.state.events)
-      })
-    }
     createDropdownItems(){
       let items = [];
       if (this.state.events != null) {
@@ -58,7 +47,7 @@ export default class EventSelector extends Component {
 
         <form>
         <label>
-            Select Event: 
+            Select Event:
             <select onChange={this.handleChange}>
             {this.createDropdownItems()}
             </select>

--- a/src/components/EventSelector.js
+++ b/src/components/EventSelector.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-export default class Home extends Component {
+export default class EventSelector extends Component {
   constructor(props) {
     super(props);
 
@@ -25,11 +25,11 @@ export default class Home extends Component {
     createDropdownItems(){
       let items = [];
       if (this.state.events != null) {
-          items.push(<option key={"-1"} 
+          items.push(<option key={"-1"}
                         value={-1}>{" "}
                     </option>)
           for (let i = 0; i < this.state.events.length; i++) {
-              items.push(<option key={i} 
+              items.push(<option key={i}
                                  value={i}>{this.state.events[i].ename}
                           </option>);
           }
@@ -56,11 +56,11 @@ export default class Home extends Component {
       else if (index === -1) {
         return (
           <div>
-            <h1>Events Check-in</h1>     
+            <h1>Events Check-in</h1>
 
-        <form> 
+        <form>
         <label>
-            Select Event:  
+            Select Event:
             <select onChange={this.handleChange}>
             {this.createDropdownItems()}
             </select>
@@ -72,11 +72,11 @@ export default class Home extends Component {
       } else {
         return (
           <div>
-            <h1>Events Check-in</h1>     
+            <h1>Events Check-in</h1>
 
-        <form> 
+        <form>
         <label>
-            Select Event:  
+            Select Event:
             <select value={this.state.selected} onChange={this.handleChange}>
             {this.createDropdownItems()}
             </select>

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react'
+import EventSelector from './EventSelector'
+const queryString = require('query-string');
+
+export default class Router extends Component {
+  render (){
+    let event = queryString.parse(window.location.search)['event']
+    if (event) {
+      return <p>{event}</p>
+    } else {
+      return (
+        <EventSelector />
+      )
+    }
+  }
+}

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -1,16 +1,48 @@
 import React, { Component } from 'react'
 import EventSelector from './EventSelector'
+import Event from './Event'
 const queryString = require('query-string');
 
 export default class Router extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      events: null,
+      event: null
+    }
+  }
+
+  componentDidMount() {
+    fetch(process.env.REACT_APP_AMAZON_API+"/events/get", {
+    })
+    .then((response) => response.json())
+    .then((response) => {
+      this.setState({
+        events: response
+      })
+      console.log(this.state.events)
+
+      let eventId = queryString.parse(window.location.search)['event']
+      if (eventId) {
+        response.forEach(event => {
+          if (event.id === eventId)
+            this.setState({ event })
+        })
+      }
+    })
+
+  }
+
   render (){
-    let event = queryString.parse(window.location.search)['event']
+    let events = this.state.events
+    let event = this.state.event
     if (event) {
-      return <p>{event}</p>
+      return <Event event={event}/>
+    } else if (!events) {
+      return <p>Loading...</p>
     } else {
-      return (
-        <EventSelector />
-      )
+      return <EventSelector events={events}/>
     }
   }
 }


### PR DESCRIPTION
- this PR is mainly to support CTRL+R, so that once an event has been selected a page refresh does not require the user to choose which event they are editing again.
- turns the dropdown list into a link. Clicking an option will redirect to that event's 'page'
- decide which event to show based on the url query param `event`, ie `localhost:3000/?event=cfn2`
- if no event is yet selected, `events/get` will be called twice (once on page load, and once when an event is selected), which is not ideal but at the moment its still fast 
- `Home.js` became `EventSelector.js` and a lot of the logic was moved to `Router.js`
- `Router.js` checks for a query param `event` and chooses whether to render the eventselector or the event page