### PR TITLE
Registration Status God Power

### DIFF
--- a/src/components/EventUserTable.js
+++ b/src/components/EventUserTable.js
@@ -59,25 +59,25 @@ export class EventUserTable extends Component {
       switch (event.target.value) {
         case REGISTRATION_STATUS.REGISTERED:
           if (window.confirm(`Do you want to register ${rowData.fname} ${rowData.lname}?
-This will send an email to the user.`)) {
+          \nThis will send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.REGISTERED);
           }
           break;
         case REGISTRATION_STATUS.CHECKED_IN:
           if (window.confirm(`Do you want to check in ${rowData.fname} ${rowData.lname}?
-This will NOT send an email to the user.`)) {
+          \nThis will NOT send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.CHECKED_IN);
           }
           break;
         case REGISTRATION_STATUS.WAITLISTED:
           if (window.confirm(`Do you want to waitlist ${rowData.fname} ${rowData.lname}?
-This will send an email to the user.`)) {
+          \nThis will send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.WAITLISTED);
           }
           break;
         case REGISTRATION_STATUS.CANCELLED:
           if (window.confirm(`Did ${rowData.fname} ${rowData.lname} cancel?
-This will send an email to the user.`)) {
+          \nThis will send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.CANCELLED);
           }
           break;

--- a/src/components/EventUserTable.js
+++ b/src/components/EventUserTable.js
@@ -84,6 +84,7 @@ export class EventUserTable extends Component {
       }
     }
 
+
     /**
      * Creates event table using MaterialTable library
      */
@@ -108,7 +109,18 @@ export class EventUserTable extends Component {
               <div>
                 <Select
                   value={rowData.registrationStatus}
-                  onClick={event => changeRegistration(event, rowData)}>
+                  onClick={event => changeRegistration(event, rowData)}
+                  style={{
+                    backgroundColor:
+                      rowData.registrationStatus === REGISTRATION_STATUS.CHECKED_IN
+                        ? "#54D26E"
+                        : rowData.registrationStatus === REGISTRATION_STATUS.WAITLISTED
+                          ? "#F7D055"
+                          : rowData.registrationStatus === REGISTRATION_STATUS.CANCELLED
+                            ? "#E15453"
+                            : "#FFF",
+                    paddingLeft: "10px"
+                  }}>
                   <MenuItem value={REGISTRATION_STATUS.WAITLISTED}>Waitlisted</MenuItem>
                   <MenuItem value={REGISTRATION_STATUS.CHECKED_IN}>Checked in</MenuItem>
                   <MenuItem value={REGISTRATION_STATUS.REGISTERED}>Registered</MenuItem>
@@ -132,14 +144,7 @@ export class EventUserTable extends Component {
             fontWeight: "bold"
           },
           rowStyle: rowData => ({
-            backgroundColor:
-              rowData.registrationStatus === REGISTRATION_STATUS.CHECKED_IN
-                ? "#54D26E"
-                : rowData.registrationStatus === REGISTRATION_STATUS.WAITLISTED
-                  ? "#FFFF00"
-                  : rowData.registrationStatus === REGISTRATION_STATUS.CANCELLED
-                    ? "#FF0000"
-                    : "#FFF"
+
           })
         }}
       //actions={[rowData => this.displayAction(rowData)]}

--- a/src/components/EventUserTable.js
+++ b/src/components/EventUserTable.js
@@ -58,26 +58,22 @@ export class EventUserTable extends Component {
     const changeRegistration = (event, rowData) => {
       switch (event.target.value) {
         case REGISTRATION_STATUS.REGISTERED:
-          if (window.confirm(`Do you want to register ${rowData.fname} ${rowData.lname}?
-          \nThis will send an email to the user.`)) {
+          if (window.confirm(`Do you want to register ${rowData.fname} ${rowData.lname}?\nThis will send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.REGISTERED);
           }
           break;
         case REGISTRATION_STATUS.CHECKED_IN:
-          if (window.confirm(`Do you want to check in ${rowData.fname} ${rowData.lname}?
-          \nThis will NOT send an email to the user.`)) {
+          if (window.confirm(`Do you want to check in ${rowData.fname} ${rowData.lname}?\nThis will NOT send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.CHECKED_IN);
           }
           break;
         case REGISTRATION_STATUS.WAITLISTED:
-          if (window.confirm(`Do you want to waitlist ${rowData.fname} ${rowData.lname}?
-          \nThis will send an email to the user.`)) {
+          if (window.confirm(`Do you want to waitlist ${rowData.fname} ${rowData.lname}?\nThis will send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.WAITLISTED);
           }
           break;
         case REGISTRATION_STATUS.CANCELLED:
-          if (window.confirm(`Did ${rowData.fname} ${rowData.lname} cancel?
-          \nThis will send an email to the user.`)) {
+          if (window.confirm(`Did ${rowData.fname} ${rowData.lname} cancel?\nThis will send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.CANCELLED);
           }
           break;

--- a/src/components/EventUserTable.js
+++ b/src/components/EventUserTable.js
@@ -58,22 +58,26 @@ export class EventUserTable extends Component {
     const changeRegistration = (event, rowData) => {
       switch (event.target.value) {
         case REGISTRATION_STATUS.REGISTERED:
-          if (window.confirm("Do you want to register " + rowData.fname + " " + rowData.lname + "?\nThis will send an email to the user.")) {
+          if (window.confirm(`Do you want to register ${rowData.fname} ${rowData.lname}?
+This will send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.REGISTERED);
           }
           break;
         case REGISTRATION_STATUS.CHECKED_IN:
-          if (window.confirm("Do you want to check-in " + rowData.fname + " " + rowData.lname + "?\nThis will NOT send an email to the user.")) {
+          if (window.confirm(`Do you want to check in ${rowData.fname} ${rowData.lname}?
+This will NOT send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.CHECKED_IN);
           }
           break;
         case REGISTRATION_STATUS.WAITLISTED:
-          if (window.confirm("Do you want to waitlist " + rowData.fname + " " + rowData.lname + "?\nThis will send an email to the user.")) {
+          if (window.confirm(`Do you want to waitlist ${rowData.fname} ${rowData.lname}?
+This will send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.WAITLISTED);
           }
           break;
         case REGISTRATION_STATUS.CANCELLED:
-          if (window.confirm("Did " + rowData.fname + " " + rowData.lname + "cancel?\nThis will send an email to the user.")) {
+          if (window.confirm(`Did ${rowData.fname} ${rowData.lname} cancel?
+This will send an email to the user.`)) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.CANCELLED);
           }
           break;

--- a/src/components/EventUserTable.js
+++ b/src/components/EventUserTable.js
@@ -145,7 +145,6 @@ export class EventUserTable extends Component {
 
           })
         }}
-      //actions={[rowData => this.displayAction(rowData)]}
       />
     );
   }

--- a/src/components/EventUserTable.js
+++ b/src/components/EventUserTable.js
@@ -17,7 +17,6 @@ export class EventUserTable extends Component {
   }
 
   async updateUserRegistrationStatus(id, registrationStatus) {
-    console.log(registrationStatus)
     const body = JSON.stringify({
       eventID: this.props.event.id,
       id: id,
@@ -57,26 +56,25 @@ export class EventUserTable extends Component {
      * @param {*} rowData data about the current row
     */
     const changeRegistration = (event, rowData) => {
-      console.log(event.target.value)
       switch (event.target.value) {
         case REGISTRATION_STATUS.REGISTERED:
-          if (window.confirm("Do you want to register " + rowData.fname + " " + rowData.lname + "?\n This will send an email to the user.")) {
+          if (window.confirm("Do you want to register " + rowData.fname + " " + rowData.lname + "?\nThis will send an email to the user.")) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.REGISTERED);
           }
           break;
         case REGISTRATION_STATUS.CHECKED_IN:
-          if (window.confirm("Do you want to check-in " + rowData.fname + " " + rowData.lname + "?\n This will send an email to the user.")) {
+          if (window.confirm("Do you want to check-in " + rowData.fname + " " + rowData.lname + "?\nThis will NOT send an email to the user.")) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.CHECKED_IN);
           }
           break;
         case REGISTRATION_STATUS.WAITLISTED:
-          if (window.confirm("Do you want to waitlist " + rowData.fname + " " + rowData.lname + "?\n This will NOT send an email to the user.")) {
+          if (window.confirm("Do you want to waitlist " + rowData.fname + " " + rowData.lname + "?\nThis will send an email to the user.")) {
             this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.WAITLISTED);
           }
           break;
         case REGISTRATION_STATUS.CANCELLED:
-          if (window.confirm("Did " + rowData.fname + " " + rowData.lname + "cancel?\n This will send an email to the user.")) {
-            this.updateUserRegistrationStatus(rowData.studentNumber, REGISTRATION_STATUS.CANCELLED);
+          if (window.confirm("Did " + rowData.fname + " " + rowData.lname + "cancel?\nThis will send an email to the user.")) {
+            this.updateUserRegistrationStatus(rowData.id, REGISTRATION_STATUS.CANCELLED);
           }
           break;
         default:


### PR DESCRIPTION
When execs navigate to an event, they can change the registration status of each person to registered, waitlisted, checked in, or cancelled (while it was just registered/checked in before). 

The row on the table will change colors appropriately:
Registered = white
Checked In = green
Waitlisted = yellow
Cancelled = red

further changes need to be made such that an email will be sent for all registration status changes, except for being checked in (backend stuff)

**NEW**
![image](https://user-images.githubusercontent.com/45786074/81756856-d55bcd00-9471-11ea-8429-8908e1c0c3f0.png)

**OLD**
![image](https://user-images.githubusercontent.com/45786074/81758521-efe47500-9476-11ea-9664-ccf4bdd08883.png)

