### PR TITLE
refactored genders to pronouns (optional field)

### DIFF
--- a/src/components/Forms/RegisterEvent.js
+++ b/src/components/Forms/RegisterEvent.js
@@ -105,11 +105,10 @@ export default function RegisterEventForm(props) {
                 <Grid item xs={12}>
                     <RadioGroupButtons
                         {...props}
-                        otherOption={false}
-                        options={["Male", "Female", "Other/Prefer not to say"]}
-                        groupName={"gender"}
-                        displayName={"Gender"}
-                    />
+                        otherOption={true}
+                        options={['He/Him/His', 'She/Her/Hers']}
+                        groupName={'gender'}
+                        displayName={'Pronouns'} />
                 </Grid>
 
                 <Grid item xs={12}>

--- a/src/components/Forms/RegisterEvent.js
+++ b/src/components/Forms/RegisterEvent.js
@@ -108,7 +108,7 @@ export default function RegisterEventForm(props) {
                         otherOption={true}
                         options={['He/Him/His', 'She/Her/Hers']}
                         groupName={'gender'}
-                        displayName={'Pronouns'} />
+                        displayName={'Preferred Pronouns'} />
                 </Grid>
 
                 <Grid item xs={12}>


### PR DESCRIPTION
refactored frontend from genders to pronouns with the options:
- He/Him/His
- She/Her/Hers
- Others (typable field)

NOTE: THE FIELD IS STILL 'gender' IN OUR BACKEND and everywhere else in the frontend - ONLY the frontend of the form has changed 