### PR TITLE
Refactored frontend to match ExpressionAttributeNames refactoring in the backend

### DIFF
--- a/src/assets/house.svg
+++ b/src/assets/house.svg
@@ -1,5 +1,5 @@
 <svg width="256" height="209" viewBox="0 0 256 209" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g opacity="0.7">
+<g opacity="1">
 <rect x="68.5414" y="54.2146" width="27.4412" height="94.8973" rx="1.87915" fill="#00C614"/>
 <path d="M125.503 45.7583L184.543 116.696H68.5414L125.503 45.7583Z" fill="#96FF50"/>
 <rect x="68.5414" y="113.408" width="116.417" height="94.8973" fill="#96FF50"/>

--- a/src/components/EventUserTable.js
+++ b/src/components/EventUserTable.js
@@ -208,7 +208,7 @@ export class EventUserTable extends Component {
         <Statistic statName='Heard about event from: ' statObj={this.state.heardFrom} />
 
         <MaterialTable
-          title={`${this.props.event.ename} Attendance`}
+          title={`${this.props.event.name} Attendance`}
           columns={[
             { title: 'First Name', field: 'fname' },
             { title: 'Last Name', field: 'lname' },

--- a/src/components/EventView.js
+++ b/src/components/EventView.js
@@ -28,7 +28,7 @@ const EventView = ({ event, children }) => {
 
       <div className={classes.content}>
         <Typography variant='h4' align='center' gutterBottom>
-          {event.ename}
+          {event.name}
         </Typography>
 
         <Markdown>

--- a/src/components/Forms/EditEvent.js
+++ b/src/components/Forms/EditEvent.js
@@ -15,7 +15,7 @@ import { Typography } from '@material-ui/core'
 
 export default function EditEventForm (props) {
   const {
-    values: { ename, slug, description, capacity, elocation, longitude, latitude, facebookUrl, imageUrl, startDate, endDate },
+    values: { name, slug, description, capacity, location, longitude, latitude, facebookUrl, imageUrl, startDate, endDate },
     errors,
     touched,
     handleSubmit,
@@ -29,8 +29,8 @@ export default function EditEventForm (props) {
   } = props
 
   useEffect(() => {
-    updatePreview({ ename, description, imageUrl })
-  }, [updatePreview, ename, description, imageUrl])
+    updatePreview({ name, description, imageUrl })
+  }, [updatePreview, name, description, imageUrl])
 
   const change = (name, e) => {
     e.persist()
@@ -87,7 +87,7 @@ export default function EditEventForm (props) {
         ;
     }
     e.persist()
-    setFieldValue('elocation', location)
+    setFieldValue('location', location)
     setFieldValue('longitude', longitude)
     setFieldValue('latitude', latitude)
   }
@@ -98,13 +98,13 @@ export default function EditEventForm (props) {
         <Grid container spacing={3}>
           <Grid item xs={12}>
             <TextField
-              id='ename'
+              id='name'
               label='Event Name'
               fullWidth
-              helperText={textFieldError('ename')}
-              error={!!textFieldError('ename')}
-              value={ename}
-              onChange={change.bind(null, 'ename')}
+              helperText={textFieldError('name')}
+              error={!!textFieldError('name')}
+              value={name}
+              onChange={change.bind(null, 'name')}
             />
           </Grid>
           <Grid item xs={12}>
@@ -172,13 +172,13 @@ export default function EditEventForm (props) {
           </Grid>
           <Grid item xs={12} sm={4}>
             <TextField
-              id='elocation'
+              id='location'
               label='Location'
               fullWidth
-              helperText={textFieldError('elocation')}
-              error={!!textFieldError('elocation')}
-              value={elocation}
-              onChange={change.bind(null, 'elocation')}
+              helperText={textFieldError('location')}
+              error={!!textFieldError('location')}
+              value={location}
+              onChange={change.bind(null, 'location')}
             />
           </Grid>
           <Grid item xs={12} sm={4}>

--- a/src/components/Forms/NewEvent.js
+++ b/src/components/Forms/NewEvent.js
@@ -16,7 +16,7 @@ const slugify = require('slugify')
 
 export default function NewEventForm (props) {
   const {
-    values: { ename, description, imageUrl, slug, startDate, endDate, elocation, longitude, latitude }, // the only values we need to store as props are the ones that are programmatically modified
+    values: { name, description, imageUrl, slug, startDate, endDate, location, longitude, latitude }, // the only values we need to store as props are the ones that are programmatically modified
     errors,
     touched,
     handleSubmit,
@@ -30,8 +30,8 @@ export default function NewEventForm (props) {
   } = props
 
   useEffect(() => {
-    updatePreview({ ename, description, imageUrl })
-  }, [updatePreview, ename, description, imageUrl])
+    updatePreview({ name, description, imageUrl })
+  }, [updatePreview, name, description, imageUrl])
 
   const change = (name, e) => {
     e.persist()
@@ -97,7 +97,7 @@ export default function NewEventForm (props) {
         ;
     }
     e.persist()
-    setFieldValue('elocation', location)
+    setFieldValue('location', location)
     setFieldValue('longitude', longitude)
     setFieldValue('latitude', latitude)
   }
@@ -108,12 +108,12 @@ export default function NewEventForm (props) {
         <Grid container spacing={3}>
           <Grid item xs={12}>
             <TextField
-              id='ename'
+              id='name'
               label='Event Name'
               fullWidth
-              helperText={textFieldError('ename')}
-              error={!!textFieldError('ename')}
-              onChange={handleEventNameChange.bind(null, 'ename')}
+              helperText={textFieldError('name')}
+              error={!!textFieldError('name')}
+              onChange={handleEventNameChange.bind(null, 'name')}
             />
           </Grid>
           <Grid item xs={12}>
@@ -181,12 +181,12 @@ export default function NewEventForm (props) {
           </Grid>
           <Grid item xs={12} sm={4}>
             <TextField
-              id='elocation'
+              id='location'
               label='Location'
               fullWidth
               helperText={textFieldError('location')}
               error={!!textFieldError('location')}
-              value={elocation}
+              value={location}
               onChange={change.bind(null, 'location')}
             />
           </Grid>

--- a/src/pages/admin/AdminHome.js
+++ b/src/pages/admin/AdminHome.js
@@ -67,7 +67,7 @@ function AdminHome (props) {
 
   const handleClickDeleteEvent = () => {
     const clickedEvent = events.find(event => event.id === eventMenuClicked)
-    if (window.confirm(`Are you sure you want to delete ${clickedEvent.ename}? This cannot be undone`)) {
+    if (window.confirm(`Are you sure you want to delete ${clickedEvent.name}? This cannot be undone`)) {
       fetchBackend(`/events/${clickedEvent.id}`, 'DELETE')
         .then(response => {
           alert(response.message)
@@ -107,7 +107,7 @@ function AdminHome (props) {
               </CardActionArea>
               <CardHeader
                 classes={{ subheader: classes.cardHeader }}
-                title={event.ename}
+                title={event.name}
                 subheader={event.startDate
                   ? new Date(event.startDate)
                     .toLocaleDateString('en-US', { day: 'numeric', weekday: 'long', month: 'long', year: 'numeric' }) : ''}

--- a/src/pages/admin/EventEdit.js
+++ b/src/pages/admin/EventEdit.js
@@ -96,7 +96,7 @@ function EventEdit (props) {
   return event && (
     <div className={classes.layout}>
       <Helmet>
-        <title>Edit {event.name} - BizTech Admin</title>
+        <title>{`Edit ${event.name} - BizTech Admin`}</title>
       </Helmet>
       <Paper className={classes.paper}>
         <div className={classes.content}>

--- a/src/pages/admin/EventEdit.js
+++ b/src/pages/admin/EventEdit.js
@@ -50,12 +50,12 @@ function EventEdit (props) {
   }
 
   const validationSchema = Yup.object({
-    ename: Yup.string().required(),
+    name: Yup.string().required(),
     description: Yup.string().required(),
     capacity: Yup.number('Valid number required')
       .min(0, 'Valid capacity required')
       .required(),
-    elocation: Yup.string().required(),
+    location: Yup.string().required(),
     longitude: Yup.number('Valid number required')
       .min(-180, 'Valid number required')
       .max(180, 'Valid number required')
@@ -69,23 +69,23 @@ function EventEdit (props) {
   })
 
   const initialValues = event ? {
-    ename: event.ename,
+    name: event.name,
     slug: event.id,
     description: event.description,
     capacity: event.capac,
     facebookUrl: event.facebookUrl,
-    elocation: event.elocation || '',
+    location: event.location || '',
     longitude: event.longitude || '',
     latitude: event.latitude || '',
     imageUrl: event.imageUrl,
     startDate: event.startDate,
     endDate: event.endDate
   } : {
-    ename: '',
+    name: '',
     description: '',
     capacity: '',
     facebookUrl: '',
-    elocation: '',
+    location: '',
     longitude: '',
     latitude: '',
     imageUrl: '',
@@ -96,7 +96,7 @@ function EventEdit (props) {
   return event && (
     <div className={classes.layout}>
       <Helmet>
-        <title>Edit {event.ename} - BizTech Admin</title>
+        <title>Edit {event.name} - BizTech Admin</title>
       </Helmet>
       <Paper className={classes.paper}>
         <div className={classes.content}>
@@ -121,10 +121,10 @@ function EventEdit (props) {
 
   async function submitValues (values) {
     const body = {
-      ename: values.ename,
+      name: values.name,
       description: values.description,
       capac: values.capacity,
-      elocation: values.elocation,
+      location: values.location,
       longitude: values.longitude,
       latitude: values.latitude,
       imageUrl: values.imageUrl,

--- a/src/pages/admin/EventNew.js
+++ b/src/pages/admin/EventNew.js
@@ -32,14 +32,14 @@ export default function EventNew () {
   const [previewEvent, setPreviewEvent] = useState({})
 
   const validationSchema = Yup.object({
-    ename: Yup.string().required(),
+    name: Yup.string().required(),
     slug: Yup.string().matches(/^[a-z\-0-9]*$/, 'Slug must be lowercase and have no whitespace').required(),
     description: Yup.string().required(),
     capacity: Yup.number('Valid number required')
       .min(0, 'Valid capacity required')
       .required(),
     // partners: Yup.string().required(),
-    elocation: Yup.string().required(),
+    location: Yup.string().required(),
     longitude: Yup.number('Valid number required')
       .min(-180, 'Valid number required')
       .max(180, 'Valid number required')
@@ -53,12 +53,12 @@ export default function EventNew () {
   })
 
   const initialValues = {
-    ename: '',
+    name: '',
     slug: '',
     description: '',
     capacity: '',
     facebookUrl: '',
-    elocation: '',
+    location: '',
     longitude: '',
     latitude: '',
     imageUrl: '',
@@ -94,11 +94,11 @@ export default function EventNew () {
 
   async function submitValues (values) {
     const body = {
-      ename: values.ename,
+      name: values.name,
       id: values.slug,
       description: values.description,
       capac: values.capacity,
-      elocation: values.elocation,
+      location: values.location,
       longitude: values.longitude,
       latitude: values.latitude,
       imageUrl: values.imageUrl,

--- a/src/pages/admin/EventView.js
+++ b/src/pages/admin/EventView.js
@@ -33,7 +33,7 @@ function EventView (props) {
   return event ? (
     <ThemeProvider>
       <Helmet>
-        <title>{event.ename} - BizTech Admin</title>
+        <title>{event.name} - BizTech Admin</title>
       </Helmet>
       <Link onClick={handleEditEventClick}>Edit Event</Link>
       <Link onClick={() => { props.history.push(`/event/${event.id}/register`) }} key={event.id}>Public Event Page</Link>

--- a/src/pages/admin/EventView.js
+++ b/src/pages/admin/EventView.js
@@ -33,7 +33,7 @@ function EventView (props) {
   return event ? (
     <ThemeProvider>
       <Helmet>
-        <title>{event.name} - BizTech Admin</title>
+        <title>{`${event.name} - BizTech Admin`}</title>
       </Helmet>
       <Link onClick={handleEditEventClick}>Edit Event</Link>
       <Link onClick={() => { props.history.push(`/event/${event.id}/register`) }} key={event.id}>Public Event Page</Link>

--- a/src/pages/member/EventRegister.js
+++ b/src/pages/member/EventRegister.js
@@ -64,7 +64,7 @@ const EventFormContainer = (props) => {
     return (
       <div className={classes.layout}>
         <Helmet>
-          <title>{event.name} - Register</title>
+          <title>{`${event.name} - Register`}</title>
         </Helmet>
         <Paper className={classes.paper}>
           <EventView event={event}>

--- a/src/pages/member/QuickRegister.js
+++ b/src/pages/member/QuickRegister.js
@@ -111,7 +111,7 @@ const EventFormContainer = (props) => {
       // the user to get to this page if they are already signed up or the event has passed
       <React.Fragment>
         <Helmet>
-          <title>{event.name} - Register</title>
+          <title>{`${event.name} - Register`}</title>
         </Helmet>
         {isSignedUp
           ? <div className={classes.layout}>

--- a/src/pages/member/QuickRegister.js
+++ b/src/pages/member/QuickRegister.js
@@ -1,21 +1,22 @@
 import React, { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { makeStyles } from '@material-ui/core/styles'
 import { fetchBackend, updateEvents } from '../../utils'
 import * as Yup from 'yup'
 import { Formik } from 'formik'
-import RegisterEvent from '../../components/Forms/RegisterEvent'
+import RegisterQuick from '../../components/Forms/RegisterQuick'
 import Paper from '@material-ui/core/Paper'
 import Grid from '@material-ui/core/Grid'
 import Skeleton from '@material-ui/lab/Skeleton'
 import { Helmet } from 'react-helmet'
-import EventView from '../../components/EventView'
+import { Typography } from '@material-ui/core'
+import House from '../../assets/house.svg'
 
 const useStyles = makeStyles(theme => ({
   layout: {
     [theme.breakpoints.up('sm')]: {
-      width: 600,
+      width: '66vw',
       margin: 'auto'
     }
   },
@@ -26,18 +27,63 @@ const useStyles = makeStyles(theme => ({
   },
   content: {
     padding: theme.spacing(3)
+  },
+  container: {
+    width: '33vw',
+    padding: '55px 0 55px 80px'
+  },
+  completeContainer: {
+    position: 'relative',
+    width: '33vw',
+    height: '78vh'
+  },
+  header: {
+    fontWeight: 'bold'
+  },
+  subHeader: {
+    fontSize: '24px'
+  },
+  house: {
+    width: '80%',
+    marginLeft: '-20px',
+    marginBottom: '-5px'
+  },
+  message: {
+    width: '40%',
+    position: 'absolute',
+    bottom: '35%',
+    left: '80%',
+    textAlign: 'center'
+  },
+  done: {
+    fontWeight: 'bold',
+    fontSize: '36px'
+  },
+  returnMessage: {
+    fontSize: '24px'
+  },
+  houseContainer: {
+    borderBottom: '1px solid white'
   }
 }))
 
 const EventFormContainer = (props) => {
   const classes = useStyles()
   const { events } = props
+  const { user } = props
+  const history = useHistory()
+
   if (!events) {
     updateEvents()
   }
   const { id: eventId } = useParams()
 
   const [event, setEvent] = useState(null)
+  const [isSignedUp, setIsSignedUp] = useState(false)
+
+  const handleReturn = () => {
+    history.push('/events')
+  }
 
   useEffect(() => {
     if (eventId && events) {
@@ -53,31 +99,53 @@ const EventFormContainer = (props) => {
       .required(),
     fname: Yup.string().required('First name is required'),
     lname: Yup.string().required('Last name is required'),
-    faculty: Yup.string().required('Faculty is required'),
     year: Yup.string().required('Level of study is required'),
     diet: Yup.string().required('Dietary restriction is required')
   })
 
-  const initialValues = { email: '', fname: '', lname: '', id: '', faculty: '', year: '', diet: '', gender: '', heardFrom: '' }
+  const initialValues = { email: user.email, fname: user.fname, lname: user.lname, id: user.id, faculty: user.faculty, year: user.year, diet: user.diet, gender: user.gender, heardFrom: '' }
 
   if (event) {
     return (
-      <div className={classes.layout}>
+      // assumes that the event details component that uses this component (QuickRegister) does not allow
+      // the user to get to this page if they are already signed up or the event has passed
+      <React.Fragment>
         <Helmet>
           <title>{event.name} - Register</title>
         </Helmet>
-        <Paper className={classes.paper}>
-          <EventView event={event}>
-            <Formik
-              initialValues={initialValues}
-              validationSchema={validationSchema}
-              onSubmit={submitValues}
-            >
-              {props => <RegisterEvent {...props} />}
-            </Formik>
-          </EventView>
-        </Paper>
-      </div>
+        {isSignedUp
+          ? <div className={classes.layout}>
+            <Paper className={classes.paper}>
+              <div className={classes.completeContainer}>
+                <div className={classes.message}>
+                  <div className={classes.houseContainer}>
+                    <img src={House} className={classes.house} alt='BizTech House' />
+                  </div>
+                  <Typography className={classes.done}>done!</Typography>
+                  <Typography>you are now registered, click <strong onClick={handleReturn} style={{ cursor: 'pointer' }}>here</strong> <br/> to return to the previous menu.</Typography>
+                </div>
+              </div>
+            </Paper>
+          </div>
+          : <div className={classes.layout}>
+            <Paper className={classes.paper}>
+              <div className={classes.container}>
+                <Typography variant='h2' className={classes.header}>
+                  {event.name}
+                </Typography>
+                <Typography className={classes.subHeader}>
+            Sign up Form
+                </Typography>
+                <Formik
+                  initialValues={initialValues}
+                  validationSchema={validationSchema}
+                  onSubmit={submitValues}>
+                  {props => <RegisterQuick {...props} />}
+                </Formik>
+              </div>
+            </Paper>
+          </div>}
+      </React.Fragment>
     )
   } else {
     return (
@@ -118,36 +186,32 @@ const EventFormContainer = (props) => {
     const { email, fname, lname, id, faculty, year, diet, heardFrom, gender } = values
     const eventID = event.id
     // TODO: Standardize the values passed to DB (right now it passes "1st Year" instead of 1)
+    const body = {
+      id,
+      fname,
+      lname,
+      email,
+      year,
+      faculty,
+      gender,
+      diet
+    }
     fetchBackend(`/users/${values.id}`, 'GET')
-      .then((response) => {
-        if (response === 'User not found.') {
-          // Need to create new user
-          // console.log("User not found, creating user");
-          const body = {
-            id,
-            fname,
-            lname,
-            email,
-            year,
-            faculty,
-            gender,
-            diet
-          }
-          fetchBackend('/users', 'POST', body)
-            .then((userResponse) => {
-              if (userResponse.message === 'Created!') {
-                registerUser(id, eventID, heardFrom)
-              } else {
-                alert('Signup failed')
-              }
-            })
-        } else {
-          registerUser(id, eventID, heardFrom)
-        }
+      .then(() => {
+        // if get response is successful
+        fetchBackend(`/users/${id}`, 'PATCH', body)
+        registerUser(id, eventID, heardFrom)
       })
-      .catch(err => {
-        console.log('registration error', err)
-        alert('Signup failed')
+      .catch(() => {
+        // Need to create new user
+        fetchBackend('/users', 'POST', body)
+          .then((userResponse) => {
+            if (userResponse.message === 'Created!') {
+              registerUser(id, eventID, heardFrom)
+            } else {
+              alert('Signup failed')
+            }
+          })
       })
   }
 
@@ -161,6 +225,7 @@ const EventFormContainer = (props) => {
     fetchBackend('/registrations', 'POST', body)
       .then((regResponse) => {
         alert('Signed Up')
+        setIsSignedUp(true)
       })
       .catch(err => {
         if (err.status === 409) {
@@ -174,7 +239,8 @@ const EventFormContainer = (props) => {
 
 const mapStateToProps = state => {
   return {
-    events: state.pageState.events
+    events: state.pageState.events,
+    user: state.userState.user
   }
 }
 

--- a/src/pages/member/UserHome.js
+++ b/src/pages/member/UserHome.js
@@ -84,7 +84,7 @@ function UserHome (props) {
                   return setNextEvent(event)
                 } else {
                   return setNextEvent({
-                    ename: 'None Registered!'
+                    name: 'None Registered!'
                   })
                 }
               }
@@ -92,7 +92,7 @@ function UserHome (props) {
           }
         } else {
           setNextEvent({
-            ename: 'None Registered!'
+            name: 'None Registered!'
           })
         }
       })
@@ -103,7 +103,7 @@ function UserHome (props) {
   }
 
   // set featured event and nextEvent on initial render
-  if (!featuredEvent.ename && !nextEvent.ename) {
+  if (!featuredEvent.name && !nextEvent.name) {
     getFeaturedEvent()
     getNextEvent()
   }
@@ -120,7 +120,7 @@ function UserHome (props) {
 
   function eventDate (date) {
     return new Date(date)
-    .toLocaleDateString('en-US', { day: 'numeric', weekday: 'long', month: 'long', year: 'numeric' })
+      .toLocaleDateString('en-US', { day: 'numeric', weekday: 'long', month: 'long', year: 'numeric' })
   }
 
   return (
@@ -151,14 +151,14 @@ function UserHome (props) {
             <div className={classes.column}>
               <CardComponent>
                 <Typography variant='h2' className={classes.green}>Next Event</Typography>
-                <Typography className={classes.eventName}>{nextEvent.ename}</Typography>
+                <Typography className={classes.eventName}>{nextEvent.name}</Typography>
                 <Typography className={classes.eventDate}>{nextEvent.startDate && eventDate(nextEvent.startDate)}</Typography>
               </CardComponent>
             </div>
             <div className={classes.column}>
               <CardComponent>
                 <Typography variant='h2' className={classes.green}>Featured</Typography>
-                <Typography className={classes.eventName}>{featuredEvent.ename}</Typography>
+                <Typography className={classes.eventName}>{featuredEvent.name}</Typography>
                 <Typography className={classes.eventDate}>{featuredEvent.startDate && eventDate(featuredEvent.startDate)}</Typography>
               </CardComponent>
             </div>


### PR DESCRIPTION
refactored all instances of ename to name, and all instances of elocation to location

also made changes to fix this error:
![image](https://user-images.githubusercontent.com/45786074/87242469-c21d9d00-c3e1-11ea-91d3-63e62b00b291.png)

NOTE: if (!featuredEvent.name && !nextEvent.name) {try to update state}<---- there will be infinite re renders on user side because of this refactor @jacqueschen1  should we delete the current table and make a new one since almost all events in the dev and prod tables have 'ename' and 'elocation' but no 'name' nor 'location'