### PR TITLE
fixed left filter bar on UserEvents page

### DIFF
--- a/src/pages/member/UserEvents.js
+++ b/src/pages/member/UserEvents.js
@@ -82,7 +82,8 @@ const useStyles = makeStyles(theme => ({
     float: 'right',
     flexDirection: 'column',
     textAlign: 'right',
-    marginRight: '3em'
+    marginRight: '3em',
+    width: '135px'
   },
   sidePanelButton: {
     textAlign: 'right',


### PR DESCRIPTION
A possible fix for issue #147.
Apparently when I clicked specifically on the 'Registered' filter in the /events page, all the other filter buttons would expand by 2px, causing the inconsistent indentation. Setting a fixed width of 135px for the sidePanelLayout class seems to resolve this problem. 

![image](https://user-images.githubusercontent.com/55124377/95166600-08756480-0763-11eb-9ef8-f042ff7c19ef.png)
![image](https://user-images.githubusercontent.com/55124377/95166773-58542b80-0763-11eb-88a1-a9b26fe1acb1.png)


