### PR TITLE
Fixed heardFrom stats table + styling updates on EventStatsTable page

### DIFF
--- a/src/constants/_constants/registration.js
+++ b/src/constants/_constants/registration.js
@@ -4,4 +4,15 @@ export const REGISTRATION_STATUS = {
   WAITLISTED: 'waitlist',
   CANCELLED: 'cancelled'
 }
+export const REGISTRATION_LABELS = {
+  registered: 'Registered',
+  checkedIn: 'Checked In',
+  waitlist: 'Waitlisted',
+  cancelled: 'Cancelled',
+  1: '1st Year',
+  2: '2nd Year',
+  3: '3rd Year',
+  4: '4th Year',
+  5: '5th+ Year'
+}
 export const EMAIL_REGEX = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/

--- a/src/pages/admin/Event/EventStats/EventStatsTable.js
+++ b/src/pages/admin/Event/EventStats/EventStatsTable.js
@@ -13,7 +13,7 @@ import {
 
 import { MenuItem, Paper, Select, Typography, makeStyles } from '@material-ui/core'
 
-import { REGISTRATION_STATUS, COLORS } from "constants/index";
+import { REGISTRATION_STATUS, REGISTRATION_LABELS, COLORS } from "constants/index";
 import { fetchBackend } from "utils";
 
 const styles = {
@@ -113,8 +113,8 @@ export class EventStatsTable extends Component {
    * calculates the stats for registration and updates the data for charts
    * each data set is an array of data (arrays) sets b/c different charts accept different data
    */
-  
-  async registrationNumbers (users) {
+
+  async registrationNumbers(users) {
     const registrations = {}
     users.forEach(user => {
       if (user.registrationStatus) {
@@ -169,7 +169,7 @@ export class EventStatsTable extends Component {
       faculties,
       years,
       genders,
-      dietary,
+      dietary
     });
   }
 
@@ -296,15 +296,15 @@ export class EventStatsTable extends Component {
                     style={{
                       backgroundColor:
                         rowData.registrationStatus ===
-                        REGISTRATION_STATUS.CHECKED_IN
+                          REGISTRATION_STATUS.CHECKED_IN
                           ? COLORS.LIGHT_GREEN
                           : rowData.registrationStatus ===
                             REGISTRATION_STATUS.WAITLISTED
-                          ? COLORS.LIGHT_YELLOW
-                          : rowData.registrationStatus ===
-                            REGISTRATION_STATUS.CANCELLED
-                          ? COLORS.LIGHT_RED
-                          : COLORS.LIGHT_BACKGROUND_COLOR,
+                            ? COLORS.LIGHT_YELLOW
+                            : rowData.registrationStatus ===
+                              REGISTRATION_STATUS.CANCELLED
+                              ? COLORS.LIGHT_RED
+                              : COLORS.LIGHT_BACKGROUND_COLOR,
                       paddingLeft: "10px",
                     }}
                   >
@@ -342,6 +342,15 @@ export class EventStatsTable extends Component {
             },
             rowStyle: (rowData) => ({}),
           }}
+          localization={{
+            body: {
+              emptyDataSourceMessage: <h2 style={{
+                color: COLORS.WHITE
+              }}
+              >No attendees to display.
+              </h2>
+            }
+          }}
         />
       </div>
     )
@@ -362,51 +371,51 @@ const Statistic = (props) => {
   const classes = useStyles()
   const [visible, setVisible] = useState(false)
 
-    const chartData = [
-      Object.keys(props.statObj).map(key => {
-        return {
-          label: key,
-          angle: props.statObj[key]
-        }
-      }),
-      Object.keys(props.statObj).map(key => {
-        return {
-          x: key,
-          y: props.statObj[key]
-        }
-      })
-    ]
+  const chartData = [
+    Object.keys(props.statObj).map(key => {
+      return {
+        label: key,
+        angle: props.statObj[key]
+      }
+    }),
+    Object.keys(props.statObj).map(key => {
+      return {
+        x: key,
+        y: props.statObj[key]
+      }
+    })
+  ]
 
-    return (
-      <Paper className={classes.paperRoot}>
-        <div style={styles.stats} onClick={() => setVisible(!visible)}>
-          <Typography style={styles.stat}>{props.statName} </Typography>
-          {Object.keys(props.statObj).map(key => (<Typography key={key} style={styles.stat}>{key}: {props.statObj[key]}</Typography>))}
-          {props.statName === 'Registration status: ' ? <Typography style={styles.stat}>Total: {Object.values(props.statObj).reduce((total, amount) => total + amount, 0)}</Typography> : <Typography />}
-        </div>
-        <div style={visible ? { display: 'flex', paddingBottom: '20px', paddingLeft: '50px' } : { display: 'none' }}>
-          <RadialChart
-            width={300}
-            height={300}
-            data={chartData[0]}
-            showLabels={true}
-            radius={140}
-            innerRadius={100}
-          />
-          <XYPlot
-            margin={{ left: 40, right: 30, top: 30, bottom: 70 }}
-            xType="ordinal"
-            width={300}
-            height={300}
-          >
-            <VerticalGridLines />
-            <HorizontalGridLines />
-            <XAxis tickLabelAngle={-45} />
-            <YAxis />
-            <VerticalBarSeries width={300} height={300} data={chartData[1]} />
-          </XYPlot>
-        </div>
-      </Paper>
-    )
+  return (
+    <Paper className={classes.paperRoot}>
+      <div style={styles.stats} onClick={() => setVisible(!visible)}>
+        <Typography style={styles.stat}>{props.statName} </Typography>
+        {Object.keys(props.statObj).map(key => (<Typography key={key} style={styles.stat}>{(key in REGISTRATION_LABELS ? REGISTRATION_LABELS[key] : key)}: {props.statObj[key]}</Typography>))}
+        {props.statName === 'Registration status: ' ? <Typography style={styles.stat}>Total: {Object.values(props.statObj).reduce((total, amount) => total + amount, 0)}</Typography> : <Typography />}
+      </div>
+      <div style={visible ? { display: 'flex', paddingBottom: '20px', paddingLeft: '50px' } : { display: 'none' }}>
+        <RadialChart
+          width={300}
+          height={300}
+          data={chartData[0]}
+          showLabels={true}
+          radius={140}
+          innerRadius={100}
+        />
+        <XYPlot
+          margin={{ left: 40, right: 30, top: 30, bottom: 70 }}
+          xType="ordinal"
+          width={300}
+          height={300}
+        >
+          <VerticalGridLines />
+          <HorizontalGridLines />
+          <XAxis tickLabelAngle={-45} />
+          <YAxis />
+          <VerticalBarSeries width={300} height={300} data={chartData[1]} />
+        </XYPlot>
+      </div>
+    </Paper>
+  )
 }
 export default EventStatsTable;

--- a/src/pages/admin/Event/EventStats/EventStatsTable.js
+++ b/src/pages/admin/Event/EventStats/EventStatsTable.js
@@ -79,7 +79,7 @@ export class EventStatsTable extends Component {
       .then((response) => {
         const heardFrom = {};
         response.data.forEach((user) => {
-          if (user.heardFromData) {
+          if (user.heardFrom) {
             heardFrom[user.heardFrom] = heardFrom[user.heardFrom]
               ? heardFrom[user.heardFrom] + 1
               : 1;

--- a/src/pages/admin/Event/EventStats/index.js
+++ b/src/pages/admin/Event/EventStats/index.js
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import { makeStyles } from "@material-ui/core/styles";
-import { Link } from "@material-ui/core";
+import { Link, Typography } from "@material-ui/core";
+import { COLORS } from "../../../../constants/_constants/theme";
 
 import NotFound from "pages/NotFound";
 import EventStatsTable from "./EventStatsTable";
@@ -13,6 +14,11 @@ const useStyles = makeStyles({
     margin: "5px",
     cursor: "pointer",
   },
+  text: {
+    margin: "2px",
+    display: 'inline-block',
+    color: COLORS.BIZTECH_GREEN
+  }
 });
 
 const EventStats = (props) => {
@@ -53,16 +59,17 @@ const EventStats = (props) => {
       <Link className={classes.link} onClick={handleEditEventClick}>
         Edit Event
       </Link>
+      <Typography className={classes.text}>|</Typography>
       <Link className={classes.link} onClick={handleEventRegisterClick}>
         Public Event Page
       </Link>
       <EventStatsTable event={event} />
     </>
   ) : (
-    <NotFound
-      message={`The event with id ${eventId} and year ${eventYear} could not be found`}
-    />
-  );
+      <NotFound
+        message={`The event with id ${eventId} and year ${eventYear} could not be found`}
+      />
+    );
 };
 
 export default EventStats;


### PR DESCRIPTION
#🎟️ Ticket(s): Closes #203

👷 Changes: A brief summary of what changes were introduced.

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots
-Changed Registration status labels (previously was "registered", "checkedIn", etc.)
<img width="379" alt="Screen Shot 2021-02-07 at 10 20 36 PM" src="https://user-images.githubusercontent.com/53382622/107184124-d421e700-6994-11eb-9578-c0a9208dded5.png">
-made this white & bolded instead of black
<img width="295" alt="Screen Shot 2021-02-07 at 10 20 12 PM" src="https://user-images.githubusercontent.com/53382622/107184154-e439c680-6994-11eb-9d12-969c44aa084c.png">
-added | in between "Edit Event" and "Public Event Page" links
<img width="227" alt="Screen Shot 2021-02-07 at 10 19 56 PM" src="https://user-images.githubusercontent.com/53382622/107184184-f6b40000-6994-11eb-846e-cb13635a6b11.png">

(prefer animated gif)

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
