### PR TITLE
Marketing request: add 'Instagram' and 'Linkedin' as options for 'where did you hear about this event' q

### DIFF
--- a/src/pages/public/Event/EventRegister/EventRegisterForm.js
+++ b/src/pages/public/Event/EventRegister/EventRegisterForm.js
@@ -180,6 +180,8 @@ export default function RegisterEventForm(props) {
               label="How did you hear about this event?"
               listOfOptions={[
                 "Facebook",
+                "Instagram",
+                "LinkedIn",
                 "Boothing",
                 "Friends",
                 "BizTech Newsletter",


### PR DESCRIPTION
<img width="254" alt="Screen Shot 2021-02-21 at 10 45 12 PM" src="https://user-images.githubusercontent.com/53382622/108672175-78785300-7496-11eb-8575-5d0a9c354fb3.png">

🎟️ Ticket(s): Closes #

👷 Changes: A brief summary of what changes were introduced.

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots

(prefer animated gif)

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
