### PR TITLE
Loading state on submitting membership form

### DIFF
--- a/src/pages/public/MembershipForm/MembershipForm.js
+++ b/src/pages/public/MembershipForm/MembershipForm.js
@@ -42,7 +42,7 @@ const useStyles = makeStyles((theme) => ({
 export default function MembershipForm(props) {
   const classes = useStyles();
 
-  const { handleSubmit, isSubmitting, memberType, setMemberType } = props;
+  const { handleSubmit, memberType, setMemberType } = props;
 
   return (
     <form className={classes.form} onSubmit={handleSubmit}>
@@ -287,7 +287,6 @@ export default function MembershipForm(props) {
         variant="contained"
         color="primary"
         type="submit"
-        disabled={isSubmitting}
       >
         <CardMembershipIcon
           style={{ color: COLORS.BACKGROUND_COLOR, marginRight: "5px" }}

--- a/src/pages/public/MembershipForm/MembershipForm.js
+++ b/src/pages/public/MembershipForm/MembershipForm.js
@@ -24,9 +24,15 @@ const useStyles = makeStyles((theme) => ({
   },
   registerButton: {
     textTransform: "none",
+    backgroundColor: COLORS.BIZTECH_GREEN,
+    color: COLORS.BACKGROUND_COLOR,
+    "&:disabled": {
+      backgroundColor: COLORS.FONT_GRAY,
+      color: COLORS.WHITE,
+    },
   },
   registerIcon: {
-    color: COLORS.FONT_COLOR,
+    color: "inherit",
     marginRight: "5px",
   },
   topics: {
@@ -42,7 +48,7 @@ const useStyles = makeStyles((theme) => ({
 export default function MembershipForm(props) {
   const classes = useStyles();
 
-  const { handleSubmit, memberType, setMemberType } = props;
+  const { isSubmitting, handleSubmit, memberType, setMemberType } = props;
 
   return (
     <form className={classes.form} onSubmit={handleSubmit}>
@@ -287,10 +293,9 @@ export default function MembershipForm(props) {
         variant="contained"
         color="primary"
         type="submit"
+        disabled={isSubmitting}
       >
-        <CardMembershipIcon
-          style={{ color: COLORS.BACKGROUND_COLOR, marginRight: "5px" }}
-        />
+        <CardMembershipIcon className={classes.registerIcon} />
         Submit
       </Button>
     </form>

--- a/src/pages/public/MembershipForm/index.js
+++ b/src/pages/public/MembershipForm/index.js
@@ -133,7 +133,6 @@ const MembershipFormContainer = (props) => {
     };
 
     setIsSubmitting(true);
-    // alert("Submitting...");
     fetchBackend("/members", "POST", body, false)
       .then(async () => {
         history.push("/signup/success");
@@ -151,9 +150,6 @@ const MembershipFormContainer = (props) => {
       });
   }
 
-  // if (isSubmitting) {
-  //   return <Loading />;
-  // } else
   return (
     <div className={classes.layout}>
       <Helmet>

--- a/src/pages/public/MembershipForm/index.js
+++ b/src/pages/public/MembershipForm/index.js
@@ -153,59 +153,57 @@ const MembershipFormContainer = (props) => {
       });
   }
 
-  if (isSubmitting) {
-    return <Loading />;
-  } else
-    return (
-      <div className={classes.layout}>
-        {/* {isSubmitting && (
-        <Loading />
-      )} */}
-        <Helmet>
-          <title>UBC BizTech Membership 2021/22</title>
-        </Helmet>
-        <Fragment>
-          <Typography className={classes.registrationText}>
-            UBC BizTech Membership 2021/22
+  // if (isSubmitting) {
+  //   return <Loading />;
+  // } else
+  return (
+    <div className={classes.layout}>
+      <Helmet>
+        <title>UBC BizTech Membership 2021/22</title>
+      </Helmet>
+      <Fragment>
+        <Typography className={classes.registrationText}>
+          UBC BizTech Membership 2021/22
+        </Typography>
+        <div className={classes.registrationHeader}>
+          <Typography>
+            Thank you for signing up to be a BizTech member! By signing up for
+            membership, you will also be a part of our mailing list!
           </Typography>
-          <div className={classes.registrationHeader}>
-            <Typography>
-              Thank you for signing up to be a BizTech member! By signing up for
-              membership, you will also be a part of our mailing list!
-            </Typography>
-            <Typography>
-              Please keep in mind that membership costs $5 and are valid for one
-              school year (Sept-May), so if you were a member last year and
-              would like to continue being part of the BizTech Network, kindly
-              renew your membership by filling out this form and send an
-              e-transfer for the amount of $5 to rita@ubcbiztech.com.
-            </Typography>
-          </div>
-          <Formik
-            initialValues={initialValues}
-            validationSchema={
-              memberType === MEMBER_TYPES.UBC
-                ? UBCValidationSchema
-                : memberType === MEMBER_TYPES.UNIVERSITY
-                ? UniversityValidationSchema
-                : memberType === MEMBER_TYPES.HIGH_SCHOOL
-                ? HighSchoolValidationSchema
-                : validationSchema
-            }
-            onSubmit={submitValues}
-          >
-            {(props) => {
-              props = {
-                ...props,
-                memberType,
-                setMemberType,
-              };
-              return <MembershipForm {...props} />;
-            }}
-          </Formik>
-        </Fragment>
-      </div>
-    );
+          <Typography>
+            Please keep in mind that membership costs $5 and are valid for one
+            school year (Sept-May), so if you were a member last year and would
+            like to continue being part of the BizTech Network, kindly renew
+            your membership by filling out this form and send an e-transfer for
+            the amount of $5 to rita@ubcbiztech.com.
+          </Typography>
+        </div>
+        <Formik
+          initialValues={initialValues}
+          validationSchema={
+            memberType === MEMBER_TYPES.UBC
+              ? UBCValidationSchema
+              : memberType === MEMBER_TYPES.UNIVERSITY
+              ? UniversityValidationSchema
+              : memberType === MEMBER_TYPES.HIGH_SCHOOL
+              ? HighSchoolValidationSchema
+              : validationSchema
+          }
+          onSubmit={submitValues}
+        >
+          {(props) => {
+            props = {
+              ...props,
+              isSubmitting,
+              memberType,
+              setMemberType,
+            };
+            return <MembershipForm {...props} />;
+          }}
+        </Formik>
+      </Fragment>
+    </div>
+  );
 };
 
 export default MembershipFormContainer;

--- a/src/pages/public/MembershipForm/index.js
+++ b/src/pages/public/MembershipForm/index.js
@@ -4,8 +4,6 @@ import { Formik } from "formik";
 import * as Yup from "yup";
 import { useHistory } from "react-router-dom";
 import MembershipForm from "./MembershipForm";
-import Loading from "pages/Loading";
-
 import { makeStyles } from "@material-ui/core/styles";
 import { Typography } from "@material-ui/core";
 import { MEMBER_TYPES } from "../../../constants/_constants/memberTypes";

--- a/src/pages/public/MembershipForm/index.js
+++ b/src/pages/public/MembershipForm/index.js
@@ -4,6 +4,7 @@ import { Formik } from "formik";
 import * as Yup from "yup";
 import { useHistory } from "react-router-dom";
 import MembershipForm from "./MembershipForm";
+import Loading from "pages/Loading";
 
 import { makeStyles } from "@material-ui/core/styles";
 import { Typography } from "@material-ui/core";
@@ -45,6 +46,7 @@ const MembershipFormContainer = (props) => {
   const history = useHistory();
 
   const [memberType, setMemberType] = useState(MEMBER_TYPES.UBC);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const validationSchema = Yup.object({
     email: Yup.string().email().required(),
@@ -132,9 +134,12 @@ const MembershipFormContainer = (props) => {
       admin,
     };
 
+    setIsSubmitting(true);
+    // alert("Submitting...");
     fetchBackend("/members", "POST", body, false)
       .then(async () => {
         history.push("/signup/success");
+        setIsSubmitting(false);
       })
       .catch((err) => {
         if (err.status === 409) {
@@ -144,56 +149,63 @@ const MembershipFormContainer = (props) => {
         } else {
           console.log(err);
         }
+        setIsSubmitting(false);
       });
   }
 
-  return (
-    <div className={classes.layout}>
-      <Helmet>
-        <title>UBC BizTech Membership 2021/22</title>
-      </Helmet>
-      <Fragment>
-        <Typography className={classes.registrationText}>
-          UBC BizTech Membership 2021/22
-        </Typography>
-        <div className={classes.registrationHeader}>
-          <Typography>
-            Thank you for signing up to be a BizTech member! By signing up for
-            membership, you will also be a part of our mailing list!
+  if (isSubmitting) {
+    return <Loading />;
+  } else
+    return (
+      <div className={classes.layout}>
+        {/* {isSubmitting && (
+        <Loading />
+      )} */}
+        <Helmet>
+          <title>UBC BizTech Membership 2021/22</title>
+        </Helmet>
+        <Fragment>
+          <Typography className={classes.registrationText}>
+            UBC BizTech Membership 2021/22
           </Typography>
-          <Typography>
-            Please keep in mind that membership costs $5 and are valid for one
-            school year (Sept-May), so if you were a member last year and would
-            like to continue being part of the BizTech Network, kindly renew
-            your membership by filling out this form and send an e-transfer for
-            the amount of $5 to rita@ubcbiztech.com.
-          </Typography>
-        </div>
-        <Formik
-          initialValues={initialValues}
-          validationSchema={
-            memberType === MEMBER_TYPES.UBC
-              ? UBCValidationSchema
-              : memberType === MEMBER_TYPES.UNIVERSITY
-              ? UniversityValidationSchema
-              : memberType === MEMBER_TYPES.HIGH_SCHOOL
-              ? HighSchoolValidationSchema
-              : validationSchema
-          }
-          onSubmit={submitValues}
-        >
-          {(props) => {
-            props = {
-              ...props,
-              memberType,
-              setMemberType,
-            };
-            return <MembershipForm {...props} />;
-          }}
-        </Formik>
-      </Fragment>
-    </div>
-  );
+          <div className={classes.registrationHeader}>
+            <Typography>
+              Thank you for signing up to be a BizTech member! By signing up for
+              membership, you will also be a part of our mailing list!
+            </Typography>
+            <Typography>
+              Please keep in mind that membership costs $5 and are valid for one
+              school year (Sept-May), so if you were a member last year and
+              would like to continue being part of the BizTech Network, kindly
+              renew your membership by filling out this form and send an
+              e-transfer for the amount of $5 to rita@ubcbiztech.com.
+            </Typography>
+          </div>
+          <Formik
+            initialValues={initialValues}
+            validationSchema={
+              memberType === MEMBER_TYPES.UBC
+                ? UBCValidationSchema
+                : memberType === MEMBER_TYPES.UNIVERSITY
+                ? UniversityValidationSchema
+                : memberType === MEMBER_TYPES.HIGH_SCHOOL
+                ? HighSchoolValidationSchema
+                : validationSchema
+            }
+            onSubmit={submitValues}
+          >
+            {(props) => {
+              props = {
+                ...props,
+                memberType,
+                setMemberType,
+              };
+              return <MembershipForm {...props} />;
+            }}
+          </Formik>
+        </Fragment>
+      </div>
+    );
 };
 
 export default MembershipFormContainer;


### PR DESCRIPTION
🎟️ Ticket(s): Closes #

👷 Changes: When a user presses 'submit', the submit button is greyed out & disabled so the user can no longer click it, until the backend call resolves & it brings them to the 'signup success' page. (Before, it would just show nothing so the user didn't know if it was submitting. This lead them to just spam the button, which would then result in error messages of 'A user with this email already exists' even though they were signing up for the first time.)

💭 Notes: 

Wait! Before you merge, have you checked the following:

📷 Screenshots

<img width="217" alt="Screen Shot 2021-12-05 at 10 00 28 AM" src="https://user-images.githubusercontent.com/53382622/144757954-4454df01-cfda-4ad6-8200-5b47223db2a2.png">

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
