### PR TITLE
Added read only property to user emails

### DIFF
--- a/src/components/inputs/CustomTextField.js
+++ b/src/components/inputs/CustomTextField.js
@@ -73,7 +73,8 @@ export default function CustomTextField (props) {
     multiline,
     rows,
     type,
-    initialValues
+    initialValues,
+    readOnly
   } = props
 
   const change = (name, e) => {
@@ -105,7 +106,8 @@ export default function CustomTextField (props) {
           classes: classes,
           inputProps: {
             classes: renderMobileOnly ? classes.mobileInput : classes.input
-          }
+          },
+          readOnly: readOnly
         }}
         rows={rows}
         defaultValue={initialValues[groupName]}
@@ -114,7 +116,7 @@ export default function CustomTextField (props) {
       />
     )
   }
-
+  
   return (
     <React.Fragment>
       <Typography>{label}</Typography>

--- a/src/pages/public/Event/EventRegister/EventRegisterForm.js
+++ b/src/pages/public/Event/EventRegister/EventRegisterForm.js
@@ -41,11 +41,7 @@ export default function RegisterEventForm (props) {
   const {
     handleSubmit,
     isSubmitting, /* isUBCStudent  setIsUBCStuden t */
-    isReadOnly, 
-    setIsReadOnly
   } = props;
-
-  setIsReadOnly(true);
 
   return (
     <form onSubmit={handleSubmit}>
@@ -76,7 +72,7 @@ export default function RegisterEventForm (props) {
             label="Email Address *"
             groupName="email"
             autoComplete="email"
-            readOnly={isReadOnly}
+            readOnly={true}
           />
         </Grid>
 

--- a/src/pages/public/Event/EventRegister/EventRegisterForm.js
+++ b/src/pages/public/Event/EventRegister/EventRegisterForm.js
@@ -40,8 +40,12 @@ export default function RegisterEventForm (props) {
 
   const {
     handleSubmit,
-    isSubmitting /* isUBCStudent  setIsUBCStuden t */
+    isSubmitting, /* isUBCStudent  setIsUBCStuden t */
+    isReadOnly, 
+    setIsReadOnly
   } = props;
+
+  setIsReadOnly(true);
 
   return (
     <form onSubmit={handleSubmit}>
@@ -72,6 +76,7 @@ export default function RegisterEventForm (props) {
             label="Email Address *"
             groupName="email"
             autoComplete="email"
+            readOnly={isReadOnly}
           />
         </Grid>
 

--- a/src/pages/public/Event/EventRegister/index.js
+++ b/src/pages/public/Event/EventRegister/index.js
@@ -54,7 +54,6 @@ const EventFormContainer = (props) => {
 
   const [registration, setRegistration] = useState(initialRegistrationState);
   // const [isUBCStudent, setIsUBCStudent] = useState(true);
-  const [isReadOnly, setIsReadOnly] = useState(false);
 
   const resetRegistration = () => setRegistration(initialRegistrationState)
 
@@ -194,8 +193,6 @@ const EventFormContainer = (props) => {
                   ...props,
                   // isUBCStudent,
                   // setIsUBCStudent,
-                  isReadOnly,
-                  setIsReadOnly,
                 };
                 return <EventRegisterForm {...props} />;
               }}

--- a/src/pages/public/Event/EventRegister/index.js
+++ b/src/pages/public/Event/EventRegister/index.js
@@ -54,6 +54,7 @@ const EventFormContainer = (props) => {
 
   const [registration, setRegistration] = useState(initialRegistrationState);
   // const [isUBCStudent, setIsUBCStudent] = useState(true);
+  const [isReadOnly, setIsReadOnly] = useState(false);
 
   const resetRegistration = () => setRegistration(initialRegistrationState)
 
@@ -193,6 +194,8 @@ const EventFormContainer = (props) => {
                   ...props,
                   // isUBCStudent,
                   // setIsUBCStudent,
+                  isReadOnly,
+                  setIsReadOnly,
                 };
                 return <EventRegisterForm {...props} />;
               }}


### PR DESCRIPTION
🎟️ Ticket(s): Closes as a user, I should not be able to change the email on the form when I register for an event

👷 Changes: A brief summary of what changes were introduced.
Set the read-only property for emails to true so they cannot be edited. 

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots

(prefer animated gif)

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/65384141/172742662-bec0bcb7-f310-4c85-b3d3-34bc96ceb920.gif)

## Checklist

- [x] Looks good on large screens
- [x] Looks good on mobile
