### PR TITLE
Add push to login screen after logout

### DIFF
--- a/src/components/layout/Navigation.js
+++ b/src/components/layout/Navigation.js
@@ -61,6 +61,7 @@ function Nav(props) {
     Auth.signOut()
       .then(() => {
         props.logout();
+        history.push('/login');
       })
       .catch((err) => console.log(err));
   };


### PR DESCRIPTION
🎟️ Ticket(s): Logging out does not redirect anywhere and causes crashes

👷 Changes: Added a redirect to the login screen after the user logs out from the dashboard

💭 Notes: If an admin user logs out while the admin-only events page is loading, the app will crash despite the redirect. All other logout scenarios (user/admin) seem to work so far

Wait! Before you merge, have you checked the following:

📷 Screenshots

![2022-06-17 14-32-05](https://user-images.githubusercontent.com/21225415/174404467-50f4c7bb-5d97-438d-b8fd-7c401c115f4d.gif)

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
