### PR TITLE
Filtered events by most recent start date

### DIFF
--- a/src/pages/admin/Home.js
+++ b/src/pages/admin/Home.js
@@ -45,6 +45,9 @@ function AdminHome(props) {
   const history = useHistory();
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [eventMenuClicked, setEventMenuClicked] = React.useState(null);
+  const filteredEvents = events.sort((a, b) => { 
+    return new Date(b.startDate) - new Date(a.startDate)
+  })
 
   const handleClick = (e, event) => {
     setAnchorEl(e.currentTarget);
@@ -147,7 +150,7 @@ function AdminHome(props) {
       </div>
 
       <Box flexWrap="wrap" display="flex">
-        {events.map((event) => createEventCard(event))}
+        {filteredEvents.map((event) => createEventCard(event))}
       </Box>
 
       <Menu

--- a/src/pages/public/EventsDashboard.js
+++ b/src/pages/public/EventsDashboard.js
@@ -271,9 +271,13 @@ function EventsDashboard (props) {
     )
 
     // filter events by time
-    const eventsFilteredByTime = eventsFilteredByPersonalization.filter(
+    let eventsFilteredByTime = eventsFilteredByPersonalization.filter(
       timeOption.filterFunction
     )
+
+    eventsFilteredByTime = eventsFilteredByTime.sort((a, b) => { 
+      return new Date(b.startDate) - new Date(a.startDate)
+    })
 
     return eventsFilteredByTime.map((event) => (
       <EventCard


### PR DESCRIPTION
🎟️ Ticket(s): Closes ticket where the events page should be showing the upcoming events first

👷 Changes: A brief summary of what changes were introduced.
Filtered the events by the most recent start date on the Home and Events dashboard

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots
The video below shows the Events dashboard.
![upcoming-evens](https://user-images.githubusercontent.com/65384141/176323003-ce6aed60-9fbd-4655-9977-b6f423c52f1a.gif)
The Home landing page has the same behaviour. 

(prefer animated gif)

## Checklist

- [x] Looks good on large screens
- [x] Looks good on mobile
