### PR TITLE
finished ticket to add registration deadline on admin view

### DIFF
--- a/src/pages/admin/DynamicForm/FormCreate.js
+++ b/src/pages/admin/DynamicForm/FormCreate.js
@@ -138,6 +138,7 @@ const FormCreateForm = (props) => {
       start,
       end,
       location,
+      deadline,
       registrationQuestions
     },
     errors,
@@ -168,6 +169,11 @@ const FormCreateForm = (props) => {
   const handleEndDateChange = (date) => {
     setFieldValue("end", date);
     setFieldTouched("end", true, false);
+  };
+
+  const handleDeadlineChange = (date) => {
+    setFieldValue("deadline", date);
+    setFieldTouched("deadline", true, false);
   };
 
   const showError = (id) => {
@@ -423,6 +429,26 @@ const FormCreateForm = (props) => {
                 error={showError("location")}
                 helperText={showError("location") && errors.location}
               />
+
+<MuiPickersUtilsProvider utils={DateFnsUtils}>
+                <Grid container spacing={1}>
+                  <Grid item xs={12}>
+                    <KeyboardDateTimePicker
+                      id="deadline"
+                      name="deadline"
+                      label="Registration Deadline"
+                      required
+                      margin="normal"
+                      inputVariant="filled"
+                      onChange={handleDeadlineChange}
+                      onBlur={handleBlur}
+                      value={deadline}
+                      error={showError("deadline")}
+                      helperText={showError("deadline") && errors.deadline}
+                    />
+                  </Grid>
+                </Grid>
+              </MuiPickersUtilsProvider>
             </div>
 
             <div style={styles.editorDivider}></div>
@@ -501,6 +527,7 @@ const FormCreate = (props) => {
         start: event.startDate ? new Date(event.startDate) : new Date(),
         end: event.endDate ? new Date(event.endDate) : new Date(),
         location: event.elocation || "",
+        deadline: event.deadline ? new Date(event.deadline) : new Date(),
         registrationQuestions: event.registrationQuestions || dummyData
       }
     : {
@@ -512,6 +539,7 @@ const FormCreate = (props) => {
         start: new Date(),
         end: new Date(),
         location: "",
+        deadline: new Date(),
         registrationQuestions: dummyData
       };
 
@@ -537,6 +565,9 @@ const FormCreate = (props) => {
       .min(Yup.ref("start"), "End must be later than Start")
       .required(),
     location: Yup.string().required(),
+    deadline: Yup.date()
+    .min(Yup.ref("start"), "Deadline must be later than Start")
+    .required(),
     registrationQuestions: Yup.array().of(regQuestionSchema)
   });
 
@@ -561,6 +592,7 @@ const FormCreate = (props) => {
       imageUrl: values.imageUrl,
       startDate: values.start,
       endDate: values.end,
+      deadline: values.deadline,
       registrationQuestions: values.registrationQuestions
     };
 
@@ -592,6 +624,7 @@ const FormCreate = (props) => {
       imageUrl: values.imageUrl,
       startDate: values.start,
       endDate: values.end,
+      deadline: values.deadline,
       registrationQuestions: values.registrationQuestions
     };
 


### PR DESCRIPTION
🎟️ Ticket(s): Closes #As an admin, I should be able to set a date and time for when the registration period of an event is over

👷 Changes: Registration form to add deadline to sign up

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots
<img width="422" alt="Screen Shot 2022-07-26 at 8 06 27 PM" src="https://user-images.githubusercontent.com/61931927/181152446-d57bc66c-4c29-408e-80cc-11fb55c74b23.png">

Also did validation to make sure it's not before start date
<img width="413" alt="Screen Shot 2022-07-26 at 8 10 53 PM" src="https://user-images.githubusercontent.com/61931927/181152518-88c997bf-abda-47e9-82b8-644b84cd47d0.png">

(prefer animated gif)

## Checklist

- [ y] Looks good on large screens
- [ x] Looks good on mobile - but tbh nothing really looks great on mobile...sowry.. it can be a backlog!
