### PR TITLE
Past events registration

### DIFF
--- a/src/pages/public/Event/EventRegister/index.js
+++ b/src/pages/public/Event/EventRegister/index.js
@@ -103,7 +103,8 @@ const EventFormContainer = (props) => {
   const { isRegistered, registeredEmail } = registration
 
   const isDeadlinePassed = (event) => {
-    return event.deadline < new Date()
+    const deadline = new Date(event.deadline).getTime()
+    return deadline < new Date().getTime()
   }
 
   if (loading) {

--- a/src/pages/public/Event/EventRegister/index.js
+++ b/src/pages/public/Event/EventRegister/index.js
@@ -102,6 +102,10 @@ const EventFormContainer = (props) => {
 
   const { isRegistered, registeredEmail } = registration
 
+  const isDeadlinePassed = (event) => {
+    return event.deadline < new Date()
+  }
+
   if (loading) {
     return (
       <div className={classes.layout}>
@@ -171,6 +175,18 @@ const EventFormContainer = (props) => {
             resetRegistration={resetRegistration}
           />
         ) : (
+          isDeadlinePassed(event) ? (
+            <Fragment>
+              <div className={classes.registrationHeader}>
+                <Typography className={classes.registrationText}>
+                  Deadline Passed
+                </Typography>
+                <Typography>
+                  The registration deadline for this event has already passed.
+                </Typography>
+              </div>
+            </Fragment>
+          ) : (
           <Fragment>
             <div className={classes.registrationHeader}>
               <Typography className={classes.registrationText}>
@@ -198,6 +214,7 @@ const EventFormContainer = (props) => {
               }}
             </Formik>
           </Fragment>
+          )
         )}
       </EventView>
     </div>


### PR DESCRIPTION
🎟️ Ticket(s): Closes As a user, I should not be able to register for an event that is past the registration period

👷 Changes: A brief summary of what changes were introduced.
The registration page now informs the user that the event registration has passed and the registration form no longer appears.

💭 Notes: Any additional things to take into consideration.
If no event deadline is included the event is considered not past the deadline. 

Wait! Before you merge, have you checked the following:

📷 Screenshots
![Screen Shot 2022-07-27 at 12 26 56 AM](https://user-images.githubusercontent.com/65384141/181162274-5f99c509-893e-4050-b641-2ef6fd042c9e.png)

(prefer animated gif)

## Checklist

- [x] Looks good on large screens
- [x] Looks good on mobile
