### PR TITLE
Adds registration deadline

### DIFF
--- a/src/pages/admin/DynamicForm/FormRegister.js
+++ b/src/pages/admin/DynamicForm/FormRegister.js
@@ -544,7 +544,13 @@ const FormRegister = (props) => {
               Deadline Passed
             </Typography>
             <Typography>
-              The registration deadline for this event has already passed.
+              The registration deadline for this event has already passed on {formData.deadline.toLocaleString(navigator.language, {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute:'2-digit'
+            })}.
             </Typography>
           </div>
         </Fragment>
@@ -563,6 +569,17 @@ const FormRegister = (props) => {
     }
     return (
       <Fragment>
+          <div style={styles.section}>
+            <Typography style={{ fontWeight: 'bold' }}>
+              Registration open now until {formData.deadline.toLocaleString(navigator.language, {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute:'2-digit'
+            })}
+            </Typography>
+          </div>
         <div style={styles.section}>{loadQuestions()}</div>
         <div style={styles.divider}></div>
         <div style={styles.submitSection}>


### PR DESCRIPTION
🎟️ Ticket(s): Closes #As an user, I should be able to see a date and time for when the registration period of an event is over

👷 Changes: A brief summary of what changes were introduced.
Adds registration deadline to the user's pov of the event registration form

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots
Deadline Passed:
![Screen Shot 2022-08-15 at 7 31 03 PM](https://user-images.githubusercontent.com/65384141/184757964-45297103-53d5-4ce3-9d31-aa2cdc92c1b7.png)
Live event:
![Screen Shot 2022-08-15 at 7 30 23 PM](https://user-images.githubusercontent.com/65384141/184757979-0a51286c-2eff-40ef-b9bc-61b2ef58544c.png)

(prefer animated gif)

## Checklist

- [x] Looks good on large screens
- [x] Looks good on mobile
