### PR TITLE
Add no events message and styling

### DIFF
--- a/src/pages/member/MemberProfile/index.js
+++ b/src/pages/member/MemberProfile/index.js
@@ -14,12 +14,13 @@ import {
   Typography
 } from '@material-ui/core'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
-
 import {
   InfoOutlined as InfoOutlinedIcon,
   CreateOutlined as OutlinedPencilIcon
 } from '@material-ui/icons'
+
 import House from 'assets/house.svg'
+import { COLORS } from 'constants/index'
 import { fetchBackend } from 'utils'
 
 const useStyles = makeStyles((theme) => ({
@@ -42,6 +43,7 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center'
   },
   header: {
+    color: COLORS.BIZTECH_GREEN,
     width: '100%',
     fontSize: 36,
     fill: 'solid',


### PR DESCRIPTION
🎟️ Ticket(s): Closes # N/A

👷 Changes: A brief summary of what changes were introduced.
added a "No matching events found" message when no events match the filtered query on member events page.
Also changed all header stylings on member pages to be BIZTECH_GREEN. (if u don't like the look lmk and i'll undo).

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:
if you have styling recommendations on the text, please share.

📷 Screenshots
<img width="1284" alt="image" src="https://user-images.githubusercontent.com/48665319/184767026-4d148115-59f3-4d49-9505-fabd354e7546.png">
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/48665319/184767576-95e00e1f-f1bf-4f29-9972-97bab6ad5c69.png">
<img width="492" alt="image" src="https://user-images.githubusercontent.com/48665319/184767683-16967824-22f3-4efc-b56c-5e9f3b0470d9.png">

(prefer animated gif)

## Checklist

- [x] Looks good on large screens
- [x] Looks good on mobile
