### PR TITLE
added the greyed out functionality to passed events

### DIFF
--- a/src/components/Event/EventCard.js
+++ b/src/components/Event/EventCard.js
@@ -10,7 +10,7 @@ import {
 const useStyles = makeStyles({
   card: {
     width: "30%",
-    margin: "15px 30px 15px 0",
+    margin: "15px 30px 15px 0"
   },
   media: {
     height: 250,
@@ -18,7 +18,13 @@ const useStyles = makeStyles({
   favouriteButton: {
     cursor: "pointer",
   },
+  passedCard: {
+    width: "30%",
+    margin: "15px 30px 15px 0",
+    opacity: "50%"
+  }
 });
+
 
 function EventCard(props) {
   const {
@@ -33,8 +39,13 @@ function EventCard(props) {
 
   const image = event.imageUrl || require("assets/default.png");
 
+  const isEventPassed = (event) => {
+    const startDate = new Date(event.startDate).getTime()
+    return startDate < new Date().getTime()
+  }
+
   return (
-    <Card className={classes.card} style={cardStyle} key={event.id}>
+    <Card className={isEventPassed(event) ? classes.passedCard : classes.card} style={cardStyle} key={event.id}>
       <CardActionArea
         onClick={(e) => {
           handleCardClick(e, event.id, event.year);
@@ -52,11 +63,11 @@ function EventCard(props) {
         subheader={
           event.startDate
             ? new Date(event.startDate).toLocaleDateString("en-US", {
-                day: "numeric",
-                weekday: "long",
-                month: "long",
-                year: "numeric",
-              })
+              day: "numeric",
+              weekday: "long",
+              month: "long",
+              year: "numeric",
+            })
             : ""
         }
         action={

--- a/src/pages/admin/Home.js
+++ b/src/pages/admin/Home.js
@@ -36,6 +36,11 @@ const useStyles = makeStyles({
     flex: "50%",
     textAlign: "left",
   },
+  passedCard: {
+    width: "45%",
+    margin: "15px 30px 15px 0",
+    opacity: "50%"
+  }
 });
 
 function AdminHome(props) {
@@ -93,10 +98,15 @@ function AdminHome(props) {
     handleClose();
   };
 
+  const isEventPassed = (event) => {
+    const startDate = new Date(event.startDate).getTime()
+    return startDate < new Date().getTime()
+  }
+
   function createEventCard(event) {
     const image = event.imageUrl || require("assets/placeholder.jpg");
     return (
-      <Card className={classes.card} key={event.id + event.year}>
+      <Card className={isEventPassed(event) ? classes.passedCard : classes.card} key={event.id + event.year}>
         <CardActionArea
           onClick={() => handleClickViewEvent(event.id, event.year)}
         >


### PR DESCRIPTION
🎟️ Ticket(s): Closes #As a user, when an event has passed, I should see past events shaded out or clearly different then current/ongoing events

👷 Changes: EventCard.js & Home.js - set a property of opacity 50%

💭 Notes: Any additional things to take into consideration.
Works on both admin, user, and past events tab

Wait! Before you merge, have you checked the following:

📷 Screenshots
<img width="759" alt="Screen Shot 2022-08-25 at 9 54 02 PM" src="https://user-images.githubusercontent.com/61931927/186825622-2219abb4-dd11-45e2-ba0e-ffe5a4012982.png">
<img width="1218" alt="Screen Shot 2022-08-25 at 9 53 49 PM" src="https://user-images.githubusercontent.com/61931927/186825626-8a07ad02-8f07-460c-8c11-c52d5912d0dd.png">
<img width="1174" alt="Screen Shot 2022-08-25 at 9 47 22 PM" src="https://user-images.githubusercontent.com/61931927/186825628-765c6e80-bfa8-4d59-ae27-4ef456270f45.png">
<img width="555" alt="Screen Shot 2022-08-25 at 10 01 13 PM" src="https://user-images.githubusercontent.com/61931927/186825741-6bdbb1cd-69ee-4a1d-a87f-61ead2bb3273.png">



## Checklist

- [ yes ] Looks good on large screens
- [ yes ] Looks good on mobile
