### PR TITLE
Make cell data compatible with PopoverCell

### DIFF
--- a/src/pages/admin/Event/EventStats/EventStatsTable.js
+++ b/src/pages/admin/Event/EventStats/EventStatsTable.js
@@ -425,9 +425,9 @@ export class EventStatsTable extends Component {
         field: "fname",
         cellStyle: { whiteSpace: "nowrap" },
         render: (rowData) => (
-          <div>
+          <>
             {rowData.fname}
-          </div>
+          </>
         )
       },
       {
@@ -435,9 +435,9 @@ export class EventStatsTable extends Component {
         field: "lname",
         cellStyle: { whiteSpace: "nowrap" },
         render: (rowData) => (
-          <div>
+          <>
             {rowData.lname}
-          </div>
+          </>
         )
       },
       {
@@ -445,9 +445,9 @@ export class EventStatsTable extends Component {
         field: "id",
         cellStyle: { whiteSpace: "nowrap" },
         render: (rowData) => (
-          <div>
+          <>
             {rowData.id}
-          </div>
+          </>
         )
       },
       {
@@ -455,9 +455,9 @@ export class EventStatsTable extends Component {
         field: "updatedAt",
         cellStyle: { whiteSpace: "nowrap" },
         render: (rowData) => (
-          <div>
+          <>
             {rowData.updatedAt}
-          </div>
+          </>
         )
       },
       {
@@ -465,9 +465,9 @@ export class EventStatsTable extends Component {
         field: "diet",
         cellStyle: { whiteSpace: "nowrap" },
         render: (rowData) => (
-          <div>
+          <>
             {rowData.diet}
-          </div>
+          </>
         )
       },
       {
@@ -475,9 +475,9 @@ export class EventStatsTable extends Component {
         field: "studentId",
         cellStyle: { whiteSpace: "nowrap" },
         render: (rowData) => (
-          <div>
+          <>
             {rowData.studentId}
-          </div>
+          </>
         )
       },
       {
@@ -485,9 +485,9 @@ export class EventStatsTable extends Component {
         field: "faculty",
         cellStyle: { whiteSpace: "nowrap" },
         render: (rowData) => (
-          <div>
+          <>
             {rowData.faculty}
-          </div>
+          </>
         )
       },
       {
@@ -495,9 +495,9 @@ export class EventStatsTable extends Component {
         field: "year",
         cellStyle: { whiteSpace: "nowrap" },
         render: (rowData) => (
-          <div>
+          <>
             {rowData.year}
-          </div>
+          </>
         )
       },
       {
@@ -505,9 +505,9 @@ export class EventStatsTable extends Component {
         field: "gender",
         cellStyle: { whiteSpace: "nowrap" },
         render: (rowData) => (
-          <div>
+          <>
             {rowData.gender}
-          </div>
+          </>
         )
       },
       {
@@ -515,9 +515,9 @@ export class EventStatsTable extends Component {
         field: "heardFrom",
         cellStyle: { whiteSpace: "nowrap" },
         render: (rowData) => (
-          <div>
+          <>
             {rowData.heardFrom}
-          </div>
+          </>
         )
       }
     ];

--- a/src/pages/admin/Event/EventStats/utils.js
+++ b/src/pages/admin/Event/EventStats/utils.js
@@ -69,9 +69,9 @@ const appendRegistrationQuestions = (columns, registrationQuestions) => {
     column.sorting = true;
     column.render = (rowData) => {
       return (
-        <div>
+        <>
           {rowData[question.questionId]}
-        </div>
+        </>
       )
     }
 


### PR DESCRIPTION
🎟️ Ticket(s): N/A
EFFECT: when an exec clicks on data within the registration table, the page will crash.

👷 Changes: A brief summary of what changes were introduced.
- The Registration Table render override using divs (#329) crashes the page because PopoverCell (#267) requires direct access to a text value. PopoverCell is used to truncate values and display a pop-up modal.
- I've reverted the divs to be [React Fragments](https://reactjs.org/docs/fragments.html) so that PopoverCell can have direct access to the text.value.
- Page no longer crashes on data click and PopoverCell's truncate/pop-up works as expected; see screenshot.

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots

![image](https://user-images.githubusercontent.com/21225415/197851985-a4c4070f-1729-4d1b-950b-f52d1875810c.png)

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
