### PR TITLE
Added timestamp to a successful QR scan

### DIFF
--- a/src/pages/public/Gamification/Redemption/index.js
+++ b/src/pages/public/Gamification/Redemption/index.js
@@ -157,6 +157,7 @@ const Redemption = ({ history, location }) => {
 
   const [pointsAwardedText, setPointsAwardedText] = useState(0);
   const [congratNameText, setCongratNameText] = useState("");
+  const [timestampText, setTimestampText] = useState("");
 
   const classes = useStyles();
 
@@ -187,15 +188,17 @@ const Redemption = ({ history, location }) => {
   const submitEmail = async () => {
     setIsLoading(true)
     if (checkEmail()) {
-      await fetchBackend("/qr", "POST", {
+      await fetchBackend("/qrscan", "POST", {
         "qrCodeID": qrID,
         "eventID": eventID,
         "year": Number(year),
-        "email": email
+        "email": email,
+        "negativePointsConfirmed": false // this is here so the api call doesn't fail for now. 
       }, false).then((res) => {
         localStorage.setItem("BP2023EMAIL", email)
         determinePointsAwardedText(res.response.redeemed_points)
         determineCongratText(res.response.first_name)
+        determineTimestampText()
         setIsModalOpen(false)
         setIsLoading(false)
       }).catch((err) => {
@@ -250,6 +253,11 @@ const Redemption = ({ history, location }) => {
       } else {
         setPointsAwardedText(`Already Redeemed`)
       }
+  }
+
+  const determineTimestampText = () => {
+    const date = new Date().toLocaleString("en-US", { timeZone: "PST" })
+    setTimestampText(date)
   }
 
   return (
@@ -352,6 +360,7 @@ const Redemption = ({ history, location }) => {
                             >
                               Return to Companion
                             </Button>
+                            <Typography className={classes.centerText} style={{ margin: "20px 0" }}>{timestampText}</Typography>
                           </motion.div>
                       </>
                   }


### PR DESCRIPTION
🎟️ Ticket(s): Closes #Innovent story 1: As a participant, I can scan QRs at the checkout of the store to spend my points. After scanning, I will have a success screen to show to the cashier at the desk with a timestamp

👷 Changes: A brief summary of what changes were introduced.
Added a timestamp 👯 

💭 Notes: Any additional things to take into consideration.
i modified the call to the QR backend only so it doesn't error, without considering behaviour for negativePointsConfirmed. 

Wait! Before you merge, have you checked the following:

📷 Screenshots
successful qr:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/48665319/221497297-f9863bee-804d-46c5-8714-8af4597e870f.png">

failed qr (doesnt include timestamp):
<img width="397" alt="image" src="https://user-images.githubusercontent.com/48665319/221497338-48dd02f0-d573-41fb-8279-edc861de7da3.png">

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
