### PR TITLE
implemented hardcoded produhacks form with split domain based questions

### DIFF
--- a/src/constants/_constants/eventRegisterForm.js
+++ b/src/constants/_constants/eventRegisterForm.js
@@ -1,0 +1,62 @@
+export const BASIC_QUESTIONS = [
+  {
+    questionType: "TEXT",
+    question: "Email Address",
+    choices: "",
+    required: true
+  },
+  {
+    questionType: "TEXT",
+    question: "First Name",
+    choices: "",
+    required: true
+  },
+  {
+    questionType: "TEXT",
+    question: "Last Name",
+    choices: "",
+    required: true
+  },
+  {
+    questionType: "SELECT",
+    question: "Year Level",
+    choices: "1st Year,2nd Year,3rd Year,4th Year,5+ Year,Other,Not Applicable",
+    required: true,
+  },
+  {
+    questionType: "SELECT",
+    question: "Faculty",
+    choices: "Arts,Commerce,Science,Engineering,Kinesiology,Land and Food Systems,Forestry,Other,Not Applicable",
+    required: true,
+  },
+  {
+    questionType: "TEXT",
+    question: "Major/Specialization",
+    choices: "",
+    required: true,
+  },
+  {
+    questionType: "SELECT",
+    question: "Preferred Pronouns",
+    choices: "He/Him/His,She/Her/Hers,They/Them/Their,Other/Prefer not to say",
+    required: true,
+  },
+  {
+    questionType: "SELECT",
+    question: "Any dietary restrictions?",
+    choices: "None,Vegetarian,Vegan,Gluten Free,Pescetarian,Kosher,Halal",
+    required: true,
+  },
+  {
+    questionType: "SELECT",
+    question: "How did you hear about this event?",
+    choices: "Boothing,Facebook,Instagram,LinkedIn,Friends/Word of Mouth,BizTech Newsletter,Other",
+    required: true,
+  },
+]
+
+export const QUESTION_DOMAINS = {
+  SWE: "SWE",
+  PM: "PM",
+  UX: "UX"
+}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -5,3 +5,5 @@ export * from "./_constants/config";
 export * from "./_constants/registration";
 
 export * from "./_constants/theme";
+
+export * from "./_constants/eventRegisterForm";


### PR DESCRIPTION
🎟️ Ticket(s): Closes #
Sets up a produhacks form which shows varying questions depending on what the user wants to apply for

👷 Changes: A brief summary of what changes were introduced.
- moved constants into constants folder for reduced clutter
- Hard codes the domains, "SWE", "PM", "UX", into FormRegister.js to be used as a `questionDomain` state property. Custom questions in the events database are tagged with `questionDomain: "SWE" | "PM" | "UX"`. 
- a new column in Events DB has been added called `hasDomainSpecificQuestions` which determines whether or not a event will use domain specific questions

💭 Notes: Any additional things to take into consideration.
- the current implementation doesn't add any column onto the admin side registrations table that shows what the user has applied for. The way for admins to distinguish applicant types is to sort by answers on domain-specific questions.
I plan on addressing this and plan to make a new iteration on this split form later when I allow for split form on the admin creation side of reg forms.

Wait! Before you merge, have you checked the following:

📷 Screenshots

https://user-images.githubusercontent.com/48665319/225200298-175e5e27-7516-42f7-ad63-7bb193568376.mov


(prefer animated gif)

## Checklist

- [X] Looks good on large screens
- [X] Looks good on mobile
