### PR TITLE
Validate start year on editing events

### DIFF
--- a/src/pages/admin/DynamicForm/FormCreate.js
+++ b/src/pages/admin/DynamicForm/FormCreate.js
@@ -815,7 +815,13 @@ const FormCreate = (props) => {
     capacity: Yup.number("Valid number required")
       .min(0, "Valid capacity required")
       .required(),
-    start: Yup.date().required(),
+    start: Yup.date().test("is-same-year", "Start date's year must be the same as eventYear", function (value) {
+      if (!eventYear || !value) {
+        return true; // Skip the test if eventYear or start date is not provided
+      }
+      const startYear = value.getFullYear();
+      return startYear === parseInt(eventYear);
+    }).required(),
     end: Yup.date()
       .min(Yup.ref("start"), "End must be later than Start")
       .required(),


### PR DESCRIPTION
🎟️ Ticket(s): Closes # https://www.notion.so/ubcbiztech/b24732925a6745caa305a2c746fa5ba7?v=d557178d0a134acf85a3890882538364&p=7f8a91ce5f984f719cf57a97dc922d98&pm=s

👷 Changes: A brief summary of what changes were introduced.

We added validation on editing a event's startYear, such that you cannot change the startYear to be differnt than the event's year. 

This solves our ticket because the bug in question only happens when an event's startYear has been edited to be different than its original year on creation. (We use the startYear to redirect the url after submitted an event edit)

By blocking admins from changing the startYear to be different from the original year on creation, this bug will never happen.

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots
<img width="1578" alt="image" src="https://github.com/ubc-biztech/bt-web/assets/48665319/52bf935c-12d4-42c9-8416-8fdde232c67a">

We also tested event creation and it still works perfectly.

## Checklist

- [X] Looks good on large screens
- [ ] Looks good on mobile
