### PR TITLE
removed extra mentor header that was added in merge

### DIFF
--- a/src/pages/public/Companion/components/CompanionLayout.js
+++ b/src/pages/public/Companion/components/CompanionLayout.js
@@ -417,11 +417,6 @@ const CompanionLayout = (params) => {
                         }}>{header.text}</Link>;
                       }
                     })}
-                    {event && <a href="#Mentors" style={{
-                      ...styles.link,
-                      fontSize: constantStyles.fontSize
-                    }}>Mentors</a>
-                    }
                   </nav>
                 </FadeInWhenVisible>
               </div>


### PR DESCRIPTION
🎟️ Ticket(s): Closes #n/a

👷 Changes: A brief summary of what changes were introduced.
in a merge in merging the mis companion, there were duplicate mentor headers created. This removes the duplicaet.



💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots
<img width="366" alt="image" src="https://github.com/ubc-biztech/bt-web/assets/48665319/527be02a-2de9-4b86-92b1-ee689fde72ff">
(prefer animated gif)

## Checklist

- [X] Looks good on large screens
- [X] Looks good on mobile
