### PR TITLE
Deauthenticated the companion call to events + updates event location on companion

### DIFF
--- a/src/pages/public/Companion/events/index.js
+++ b/src/pages/public/Companion/events/index.js
@@ -90,7 +90,7 @@ export default [
       /* Displayed date of event */
       date: "Friday, September 15th",
       // @TODO change this
-      location: "TBD",
+      location: "UBC Asian Centre Auditorium",
       // @TODO change this
       colors: {
         primary: "linear-gradient(180deg, #FFFFFF, #FFFFFF)",

--- a/src/pages/public/Companion/index.js
+++ b/src/pages/public/Companion/index.js
@@ -71,7 +71,7 @@ const Companion = () => {
   };
 
   const fetchEvent = async () => {
-    await fetchBackend(`/events/${eventID}/${year}`, "GET", undefined)
+    await fetchBackend(`/events/${eventID}/${year}`, "GET", undefined, false)
       .then((response) => {
         setEvent(response);
       }).catch((err) => {


### PR DESCRIPTION
🎟️ Ticket(s): Closes #
https://www.notion.so/ubcbiztech/b24732925a6745caa305a2c746fa5ba7?v=d557178d0a134acf85a3890882538364&p=d03551bec133407d93ca81d2c45f7b1c&pm=s

👷 Changes: A brief summary of what changes were introduced.
set authentication to false on the call to events/id/year on the companion app. 
This fixes a bug where the companion app was inaccessible if you were logged out on the regular events app

Also adds the locaiton of the event to be asian centre

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots

(prefer animated gif)
<img width="1714" alt="image" src="https://github.com/ubc-biztech/bt-web/assets/48665319/08e9987e-3a0b-4580-80fc-0fd021cfaa82">


## Checklist

- [X] Looks good on large screens
- [X] Looks good on mobile
