### PR TITLE
changed the file upload types to include images in registration forms

### DIFF
--- a/src/pages/admin/DynamicForm/FormRegister.js
+++ b/src/pages/admin/DynamicForm/FormRegister.js
@@ -704,7 +704,7 @@ const FormRegister = (props) => {
                 <input
                   hidden
                   type="file"
-                  accept="application/pdf"
+                  accept="application/pdf, image/jpg, image/png, image/jpeg"
                   onChange={(e) => uploadFile(i, e)}
                 />
               </Button>

--- a/src/pages/admin/DynamicForm/FormRegisterPartner.js
+++ b/src/pages/admin/DynamicForm/FormRegisterPartner.js
@@ -521,7 +521,7 @@ const FormRegisterPartner = (props) => {
                   color: "black",
                   marginLeft: 6
                 }}/>
-                <input hidden type="file" accept="application/pdf" onChange={(e) => uploadFile(i, e)}/>
+                <input hidden type="file" accept="application/pdf, image/jpg, image/png, image/jpeg" onChange={(e) => uploadFile(i, e)}/>
               </Button>
               {!!responseError[i] && (
                 <FormHelperText>{responseError[i]}</FormHelperText>


### PR DESCRIPTION
🎟️ Ticket(s): Closes #
So that Blueprint partners can upload their headshot using our web app.

👷 Changes: A brief summary of what changes were introduced.
The File Upload type question now allows for jpg, png, jpeg.

💭 Notes: Any additional things to take into consideration.
IDEALLY we also address the ticket where files get uploaded to a event specific folder.
Feel free to add onto this branch for that feature.

Wait! Before you merge, have you checked the following:

📷 Screenshots

(prefer animated gif)
<img width="1005" alt="image" src="https://github.com/ubc-biztech/bt-web/assets/48665319/638740b7-8035-41a4-bb28-010c7b42c92b">


## Checklist

- [X] Looks good on large screens
- [X] Looks good on mobile
