### PR TITLE
Uploads go into seperate folder in dev drive

### DIFF
--- a/src/pages/admin/DynamicForm/FormRegister.js
+++ b/src/pages/admin/DynamicForm/FormRegister.js
@@ -426,12 +426,14 @@ const FormRegister = (props) => {
           dataReq: {
             data: rawLog,
             name: file.name,
-            type: file.type
+            type: file.type,
+            folderId: currEvent.id
+
           },
-          fname: "uploadFilesToGoogleDrive"
+          fname: "uploadFilesToGoogleDrive",
         }; // preapre info to send to API
         fetch(
-          "https://script.google.com/macros/s/AKfycbyX8joJ5WeyqZxrUh-iS-Cay17N3ygO-YMuoNVaBN5o4jl6Cy0k9X0JcxRrwiWy1OEoiQ/exec", // your AppsScript URL
+          "https://script.google.com/macros/s/AKfycbzLif9Uypau-R54Ob-g3bs9jqWujIzfXFvZEMKx7k5m3KfZZNlPUwj-dIdKh7dMaxTotA/exec", // your AppsScript URL
           {
             method: "POST",
             body: JSON.stringify(dataSend)
@@ -443,12 +445,13 @@ const FormRegister = (props) => {
           })
           .catch((e) =>
             alert(
-              "An error occurred while trying to upload the file. Please try again."
+              e
+              // "An error occurred while trying to upload the file. Please try again."
             )
           );
       };
     },
-    [updateField]
+    [updateField, currEvent.ename]
   );
 
   const loadQuestions = () => {


### PR DESCRIPTION
🎟️ Ticket(s): Closes #Make File uploads separate by event

👷 Changes: A brief summary of what changes were introduced.

- Most of the changes were in https://script.google.com/home accessible from dev account.
  - I created a new script which takes in an additional feature folderID
  - If a folder already exists with the same name, the upload goes into that folder.
  - If not, then a new folder is created with the folderID name passed through.
  
The script is called _Updated BT-Web Uploads_

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots
<img width="1160" alt="Screen Shot 2023-11-11 at 17 24 09" src="https://github.com/ubc-biztech/bt-web/assets/97780809/062b8e22-81b0-4d26-8014-c501af1c6937">
<img width="1153" alt="Screen Shot 2023-11-11 at 17 24 06" src="https://github.com/ubc-biztech/bt-web/assets/97780809/431c5daf-2820-402d-a95f-c3fec75a84f8">

(prefer animated gif)

## Checklist

- [X] Looks good on large screens
- [X] Looks good on mobile
