### PR TITLE
Add Resend Verification On Login

### DIFF
--- a/src/pages/public/Login.js
+++ b/src/pages/public/Login.js
@@ -166,6 +166,12 @@ function Login() {
     return error;
   };
 
+  const resendVerificationEmail = async () => {
+    await Auth.resendSignUp(email).then(() => {
+      alert("Verification Email Resent!");
+    });
+  };
+
   const handleSubmit = async () => {
     const emailError = validateEmail(email);
     const passwordError = validatePassword(password);
@@ -191,6 +197,21 @@ function Login() {
           setErrors({
             emailError: "",
             passwordError: "Incorrect username or password."
+          });
+        } else if (error.code === "UserNotConfirmedException") {
+          setErrors({
+            emailError: "",
+            passwordError: (<>User is not verified.
+              <br /><span style={{
+                textDecoration: "underline",
+                color: "white",
+                cursor: "pointer"
+              }}
+              onClick={() => resendVerificationEmail()}>Click here</span>
+              <span style={{
+                color: "white"
+              }}> to resend the verification code.</span></>),
+            verificationCodeError: ""
           });
         } else {
           setErrors({


### PR DESCRIPTION
🎟️ Ticket(s): Closes #

👷 Changes: A brief summary of what changes were introduced.
Added a button to resend verification email on the signing page. When an unverified email tries to log in, they will be able to resend it to their email.

💭 Notes: Any additional things to take into consideration.
local frontend env was fixed, works fine

Wait! Before you merge, have you checked the following:

📷 Screenshots
![image](https://github.com/ubc-biztech/bt-web/assets/143137665/cece1f37-2120-4ae2-bf18-c0b5b6a53444)


(prefer animated gif)

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
