### PR TITLE
fixed the view all qrs screen for qrs of type Partner with missing va…

### DIFF
--- a/src/pages/admin/Companion/index.js
+++ b/src/pages/admin/Companion/index.js
@@ -409,7 +409,7 @@ const Companion = () => {
                     </Box>
                     <Box>Type: {QR.type}</Box>
                     {QR.type === "Partner" &&
-                      <Box>Partner Email: {QR.data.partnerID}</Box>
+                      <Box>Partner Email: {QR.data ? QR.data.partnerID : ""}</Box>
                     }
                   </Box>
                   <img


### PR DESCRIPTION
🎟️ Ticket(s): Closes #

👷 Changes: A brief summary of what changes were introduced.

the view all qrs screen was broken because some Partner QR's with type = "Partner" don't have a partnerID associated to it in our db, so we were getting null pointer errors.

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots

(prefer animated gif)

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
