### PR TITLE
made student id non read only

### DIFF
--- a/src/pages/public/RegistrationForms/MembershipForm/MembershipForm.js
+++ b/src/pages/public/RegistrationForms/MembershipForm/MembershipForm.js
@@ -149,7 +149,6 @@ export default function MembershipForm(props) {
           <Grid item xs={12}>
             <CustomTextField
               {...props}
-              readOnly={true}
               label="Student Number *"
               groupName="student_number"
               autoComplete="student_number"


### PR DESCRIPTION
🎟️ Ticket(s): Closes #
bug on #dev-help ???? MAYBE?

👷 Changes: A brief summary of what changes were introduced.
make student id non read only on the membership sign up form for people who have accounts but aren't yet members.
i don't know if this is exactly what is causing the bug in #dev-help on slack, but hopefully it does? idk the bug remains unreproducable


💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots
didn't test ngl

(prefer animated gif)

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
