### PR TITLE
made event stats table show reg stats dependent on whether attendee or partner regs are viewed

### DIFF
--- a/src/pages/admin/Event/EventStats/utils.js
+++ b/src/pages/admin/Event/EventStats/utils.js
@@ -36,7 +36,7 @@ const parseDynamicResponses = (registrations) => {
  * Helper function to flatten the registration data into a format suitable for the MaterialTable
  * @param {*} users the response from the registration backend
  */
-const prepareRowData = (users) => {
+const flattenRowData = (users) => {
   const idToUserMap = new Map();
 
   users.forEach((user) => {
@@ -92,6 +92,6 @@ export {
   REGISTRATIONSTATUSLABEL,
   POINTSLABEL,
   parseDynamicResponses,
-  prepareRowData,
+  flattenRowData,
   appendRegistrationQuestions,
 };


### PR DESCRIPTION
🎟️ Ticket(s): Closes #
for funsies (also bc it caused major panic when we say 270 regs at blueprint when there was 220 limit)

👷 Changes: A brief summary of what changes were introduced.
the events registsration table now shows stats at the bottom specific to attendee or partner

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots

https://github.com/ubc-biztech/bt-web/assets/48665319/a12c375a-280c-4474-962a-7afbaec7df74

^^ audio on please
(prefer animated gif)

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
