### PR TITLE
Prompt user payment on application based events after

### DIFF
--- a/src/pages/admin/DynamicForm/FormRegister.js
+++ b/src/pages/admin/DynamicForm/FormRegister.js
@@ -865,7 +865,7 @@ const FormRegister = (props) => {
           } else {
             const paymentBody = {
               paymentName: `${currEvent.ename} ${user?.isMember || samePricing() ? "" : "(Non-member)"
-                }`,
+              }`,
               paymentImages: [formData.image_url],
               paymentPrice:
                 (user?.isMember
@@ -875,11 +875,11 @@ const FormRegister = (props) => {
               success_url: `${process.env.REACT_APP_STAGE === "local"
                 ? "http://localhost:3000/"
                 : CLIENT_URL
-                }event/${currEvent.id}/${currEvent.year}/register/success`,
+              }event/${currEvent.id}/${currEvent.year}/register/success`,
               cancel_url: `${process.env.REACT_APP_STAGE === "local"
                 ? "http://localhost:3000/"
                 : CLIENT_URL
-                }event/${currEvent.id}/${currEvent.year}/register`,
+              }event/${currEvent.id}/${currEvent.year}/register`,
               email: responseData[0],
               fname: responseData[1],
               eventID: currEvent.id,
@@ -1001,37 +1001,37 @@ const FormRegister = (props) => {
 
   const changeRegStatus = (newStatus) => {
     switch (newStatus) {
-      case REGISTRATION_STATUS.REGISTERED:
-        if (
-          window.confirm(
-            `Do you want to re-register for ${event.ename || "this event"
-            }?\nYou will be sent an email confirming your registration.`
-          )
-        ) {
-          updateUserRegistrationStatus(
-            user?.email,
-            user?.fname,
-            REGISTRATION_STATUS.REGISTERED
-          );
-        }
-        break;
-      case REGISTRATION_STATUS.CANCELLED:
-        if (
-          window.confirm(
-            `Are you sure you would cancel your spot at ${event.ename || "this event"
-            }?\nYou will be sent an email regarding your cancellation.`
-          )
-        ) {
-          updateUserRegistrationStatus(
-            user?.email,
-            user?.fname,
-            REGISTRATION_STATUS.CANCELLED
-          );
-        }
-        break;
-      default:
-        return {
-        };
+    case REGISTRATION_STATUS.REGISTERED:
+      if (
+        window.confirm(
+          `Do you want to re-register for ${event.ename || "this event"
+          }?\nYou will be sent an email confirming your registration.`
+        )
+      ) {
+        updateUserRegistrationStatus(
+          user?.email,
+          user?.fname,
+          REGISTRATION_STATUS.REGISTERED
+        );
+      }
+      break;
+    case REGISTRATION_STATUS.CANCELLED:
+      if (
+        window.confirm(
+          `Are you sure you would cancel your spot at ${event.ename || "this event"
+          }?\nYou will be sent an email regarding your cancellation.`
+        )
+      ) {
+        updateUserRegistrationStatus(
+          user?.email,
+          user?.fname,
+          REGISTRATION_STATUS.CANCELLED
+        );
+      }
+      break;
+    default:
+      return {
+      };
     }
   };
 
@@ -1072,16 +1072,16 @@ const FormRegister = (props) => {
 
   const renderRegMessage = (status) => {
     switch (status) {
-      case REGISTRATION_STATUS.CANCELLED:
-        return `You have cancelled your registration for ${currEvent.ename || "this event"
-          }.`;
-      case REGISTRATION_STATUS.WAITLISTED:
-        return `You are currently waitlisted for ${currEvent.ename || "this event"
-          }.`;
-      case REGISTRATION_STATUS.INCOMPLETE:
-        return "You have not completed your payment yet!";
-      default:
-        return `Already registered for ${currEvent.ename || "this event"}!`;
+    case REGISTRATION_STATUS.CANCELLED:
+      return `You have cancelled your registration for ${currEvent.ename || "this event"
+      }.`;
+    case REGISTRATION_STATUS.WAITLISTED:
+      return `You are currently waitlisted for ${currEvent.ename || "this event"
+      }.`;
+    case REGISTRATION_STATUS.INCOMPLETE:
+      return "You have not completed your payment yet!";
+    default:
+      return `Already registered for ${currEvent.ename || "this event"}!`;
     }
   };
 
@@ -1275,38 +1275,38 @@ const FormRegister = (props) => {
           {!user?.admin &&
             ((user?.isMember && currEvent.pricing?.members > 0) ||
               (!user?.isMember && currEvent.pricing?.nonMembers)) ? (
-            currEvent.isApplicationBased ? (
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handlePaymentSubmit}
-                disabled={isSubmitting}
-              >
+              currEvent.isApplicationBased ? (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handlePaymentSubmit}
+                  disabled={isSubmitting}
+                >
                 Submit
-              </Button>
+                </Button>
+              ) : (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handlePaymentSubmit}
+                  className={classes.registerButton}
+                  disabled={isSubmitting}
+                >
+                  <CardMembershipIcon className={classes.registerIcon} />
+                Proceed to Payment
+                </Button>
+              )
             ) : (
               <Button
                 variant="contained"
                 color="primary"
-                onClick={handlePaymentSubmit}
+                onClick={handleSubmit}
                 className={classes.registerButton}
                 disabled={isSubmitting}
               >
-                <CardMembershipIcon className={classes.registerIcon} />
-                Proceed to Payment
-              </Button>
-            )
-          ) : (
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleSubmit}
-              className={classes.registerButton}
-              disabled={isSubmitting}
-            >
               Submit
-            </Button>
-          )}
+              </Button>
+            )}
         </div>
 
       </Fragment>


### PR DESCRIPTION
🎟️ Ticket(s): Closes #

👷 Changes: A brief summary of what changes were introduced.
Prompt user payment on application based events AFTER they are accepted - changes to FormRegister.js to change Proceed to Payment to "Submit" on application based events that require payment. Redirects user straight to success page after registration. Adds users to registration data as incomplete, for payment link to be sent on acceptance. 

💭 Notes: Any additional things to take into consideration.
My prettier extension may have fumbled a few indents and or new line changes, which is why it says there are so many edits.

Wait! Before you merge, have you checked the following:

📷 Screenshots
<img width="782" alt="image" src="https://github.com/ubc-biztech/bt-web/assets/143137665/5ef356e3-3181-4e88-8a1a-a0d4448325e3">


(prefer animated gif)

## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
