### PR TITLE
enabled checkout link when link doesn't exist yet

### DIFF
--- a/src/pages/public/Companion/events/Produhacks2024.js
+++ b/src/pages/public/Companion/events/Produhacks2024.js
@@ -118,7 +118,7 @@ const Produhacks2024 = (params) => {
           fontSize: constantStyles.mobileFontSize
         })
       }}>You're all set! Be on the lookout in your email for more details. </span> :
-        userRegistration.checkoutLink && <div style={customStyles.options}><span style={{
+        <div style={customStyles.options}><span style={{
           ...styles.text,
           ...(renderMobileOnly && {
             fontSize: constantStyles.mobileFontSize


### PR DESCRIPTION
🎟️ Ticket(s): Closes #
BUG fix

👷 Changes: A brief summary of what changes were introduced.
Checkout link wasn't showing since registration.checkoutLink is no longer generated upon applying.

We don't need to check for registration.checkoutLink anymore because of @AllanT102's feature of auto generating link

💭 Notes: Any additional things to take into consideration.

Wait! Before you merge, have you checked the following:

📷 Screenshots

(prefer animated gif)
<img width="712" alt="image" src="https://github.com/ubc-biztech/bt-web/assets/48665319/b7eb21ff-1833-4c23-8d47-c3d69e987d69">


## Checklist

- [ ] Looks good on large screens
- [ ] Looks good on mobile
