### PR TITLE
Fix unnecessary email lowercase

### DIFF
--- a/src/pages/public/RegistrationForms/MembershipForm/index.js
+++ b/src/pages/public/RegistrationForms/MembershipForm/index.js
@@ -208,7 +208,7 @@ const MembershipFormContainer = (props) => {
       fname: first_name,
       lname: last_name,
       major: memberType === "UBC" || memberType === "UNI" ? major : "",
-      email: email.toLowerCase(),
+      email: user.email,
       year: memberType !== "NA" ? year : "",
       faculty: memberType === "UBC" || memberType === "UNI" ? faculty : "",
       pronouns: pronouns || "Other/Prefer not to say",


### PR DESCRIPTION
## Why?
Memberships are not being associated properly when a returning BizTech user signs up for a new membership. Their email is automatically converted to lowercase in the membership registration form, but their email key in the users DB might not be all lowercase, so we aren't able to associate the membership to the user. This results in our payments webhook failing to set the user to having `isMember=true`, as seen in the Slack thread.

## Fix
Email is grabbed from the source of truth on the correct capitalization, `user.email`. We are already passing this in via the `user` prop, and `user.email` is being used to pre-fill the form.

## Testing
Need to test in `dev` first before we merge to `master`

Related slack thread: https://ubcbiztech202425.slack.com/archives/C071AMV247P/p1725431742940669