### PR TITLE
updated event date to be active until oct 8 2024

### DIFF
--- a/src/pages/public/Companion/events/index.js
+++ b/src/pages/public/Companion/events/index.js
@@ -394,7 +394,7 @@ export default [
   },
   {
     /* Date indicating when event ends, this also indicates which app the companion app will render, to be safe, but a couple days after event ends */
-    activeUntil: new Date(new Date("09-18-2024").getTime() + (7 * 24 * 60 * 60 * 1000)), // change 3 days after date
+    activeUntil: new Date(new Date("2024-10-08").getTime() + (7 * 24 * 60 * 60 * 1000)),
     /* id of event in dynamodb, used for queries */
     eventID: "hello-hacks",
     /* year of event in dynamodb, used for queries */


### PR DESCRIPTION
👷 Changes: just updated the 'activeUntil' field to be a couple days after hello hacks

💭 Notes: tested by creating hello-hacks 2024 event on bt-web 

<img width="1462" alt="Screen Shot 2024-09-25 at 3 29 58 PM" src="https://github.com/user-attachments/assets/e34ff98e-a7f0-4d37-b074-80ebe9943e86">

