### PR TITLE
Add createdAt column in registration table

### DIFF
--- a/src/pages/admin/Event/EventStats/TableColumns.js
+++ b/src/pages/admin/Event/EventStats/TableColumns.js
@@ -103,23 +103,6 @@ const getDefaultColumns = (eventID, eventYear, refreshTable, tableType) => [
     )
   },
   {
-    title: "Last Updated",
-    field: "updatedAt",
-    customSort: (a, b) => {
-      const timestampA = Date.parse(a.updatedAt);
-      const timestampB = Date.parse(b.updatedAt);
-      return timestampA - timestampB;
-    },
-    cellStyle: {
-      whiteSpace: "nowrap"
-    },
-    render: (rowData) => (
-      <>
-        {rowData.updatedAt}
-      </>
-    )
-  },
-  {
     title: "Date Created",
     field: "createdAt",
     customSort: (a, b) => {
@@ -133,6 +116,23 @@ const getDefaultColumns = (eventID, eventYear, refreshTable, tableType) => [
     render: (rowData) => (
       <>
         {rowData.createdAt === "Invalid Date" ? "" : rowData.createdAt}
+      </>
+    )
+  },
+  {
+    title: "Last Updated",
+    field: "updatedAt",
+    customSort: (a, b) => {
+      const timestampA = Date.parse(a.updatedAt);
+      const timestampB = Date.parse(b.updatedAt);
+      return timestampA - timestampB;
+    },
+    cellStyle: {
+      whiteSpace: "nowrap"
+    },
+    render: (rowData) => (
+      <>
+        {rowData.updatedAt}
       </>
     )
   },
@@ -282,23 +282,6 @@ const getDefaultPartnerColumns = (eventID, eventYear, refreshTable) => [
     )
   },
   {
-    title: "Last Updated",
-    field: "updatedAt",
-    customSort: (a, b) => {
-      const timestampA = Date.parse(a.updatedAt);
-      const timestampB = Date.parse(b.updatedAt);
-      return timestampA - timestampB;
-    },
-    cellStyle: {
-      whiteSpace: "nowrap"
-    },
-    render: (rowData) => (
-      <>
-        {rowData.updatedAt}
-      </>
-    )
-  },
-  {
     title: "Date Created",
     field: "createdAt",
     customSort: (a, b) => {
@@ -312,6 +295,23 @@ const getDefaultPartnerColumns = (eventID, eventYear, refreshTable) => [
     render: (rowData) => (
       <>
         {rowData.createdAt === "Invalid Date" ? "" : rowData.createdAt}
+      </>
+    )
+  },
+  {
+    title: "Last Updated",
+    field: "updatedAt",
+    customSort: (a, b) => {
+      const timestampA = Date.parse(a.updatedAt);
+      const timestampB = Date.parse(b.updatedAt);
+      return timestampA - timestampB;
+    },
+    cellStyle: {
+      whiteSpace: "nowrap"
+    },
+    render: (rowData) => (
+      <>
+        {rowData.updatedAt}
       </>
     )
   },

--- a/src/pages/admin/Event/EventStats/TableColumns.js
+++ b/src/pages/admin/Event/EventStats/TableColumns.js
@@ -120,6 +120,23 @@ const getDefaultColumns = (eventID, eventYear, refreshTable, tableType) => [
     )
   },
   {
+    title: "Date Created",
+    field: "createdAt",
+    customSort: (a, b) => {
+      const timestampA = Date.parse(a.createdAt);
+      const timestampB = Date.parse(b.createdAt);
+      return timestampA - timestampB;
+    },
+    cellStyle: {
+      whiteSpace: "nowrap"
+    },
+    render: (rowData) => (
+      <>
+        {rowData.createdAt === "Invalid Date" ? "" : rowData.createdAt}
+      </>
+    )
+  },
+  {
     title: "Diet",
     field: "diet",
     cellStyle: {
@@ -278,6 +295,23 @@ const getDefaultPartnerColumns = (eventID, eventYear, refreshTable) => [
     render: (rowData) => (
       <>
         {rowData.updatedAt}
+      </>
+    )
+  },
+  {
+    title: "Date Created",
+    field: "createdAt",
+    customSort: (a, b) => {
+      const timestampA = Date.parse(a.createdAt);
+      const timestampB = Date.parse(b.createdAt);
+      return timestampA - timestampB;
+    },
+    cellStyle: {
+      whiteSpace: "nowrap"
+    },
+    render: (rowData) => (
+      <>
+        {rowData.createdAt === "Invalid Date" ? "" : rowData.createdAt}
       </>
     )
   },

--- a/src/pages/admin/Event/EventStats/utils.js
+++ b/src/pages/admin/Event/EventStats/utils.js
@@ -49,6 +49,7 @@ const flattenRowData = (users) => {
       applicationStatus: user.applicationStatus,
       // convert the date to something more readable
       updatedAt: new Date(user.updatedAt).toLocaleString(),
+      createdAt: new Date(user.createdAt).toLocaleString(),
       isPartner: user.isPartner,
       points: user.points,
       teamID: user.teamID,


### PR DESCRIPTION
🎟️ Ticket(s): Closes [this ticket](https://github.com/orgs/ubc-biztech/projects/4?pane=issue&itemId=84600888)

👷 Changes: A brief summary of what changes were introduced.
- Added createdAt column in table 

💭 Notes: Any additional things to take into consideration.
- Tested on local with backend changes made in this PR: https://github.com/ubc-biztech/serverless-biztechapp/pull/398
- For testing I just register users and check that the createdAt time doesn't update when the registrationStatus is updated
- I have no idea how to check if this works for partner registration

After creation:
<img width="1351" alt="Screenshot 2024-11-06 at 12 38 25 AM" src="https://github.com/user-attachments/assets/95f92e00-9a67-41b9-80da-d84bb0d1324f">
After update:
<img width="1363" alt="Screenshot 2024-11-06 at 12 38 55 AM" src="https://github.com/user-attachments/assets/93630cd8-e9ca-45d5-810a-be9af6556a45">

